### PR TITLE
feat: add prisma schema and seed

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -14,15 +14,21 @@
     "@nestjs/core": "^10.2.5",
     "@nestjs/platform-express": "^10.2.5",
     "@nestjs/swagger": "^7.1.12",
+    "@prisma/client": "^5.4.1",
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.8.1",
-    "zod": "^3.22.2",
-    "@prisma/client": "^5.4.1"
+    "zod": "^3.22.2"
   },
   "devDependencies": {
-    "typescript": "^5.3.0",
-    "ts-node-dev": "^2.0.0",
+    "@typescript-eslint/eslint-plugin": "^6.21.0",
+    "@typescript-eslint/parser": "^6.21.0",
     "eslint": "^8.50.0",
-    "prisma": "^5.4.1"
+    "prisma": "^5.4.1",
+    "ts-node": "^10.9.1",
+    "ts-node-dev": "^2.0.0",
+    "typescript": "^5.3.0"
+  },
+  "prisma": {
+    "seed": "ts-node prisma/seed.ts"
   }
 }

--- a/apps/api/prisma/migrations/001_init/migration.sql
+++ b/apps/api/prisma/migrations/001_init/migration.sql
@@ -1,0 +1,351 @@
+-- CreateEnum
+CREATE TYPE "Role" AS ENUM ('landlord', 'property_manager', 'tenant', 'tradesperson', 'admin');
+
+-- CreateTable
+CREATE TABLE "Organization" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Organization_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "User" (
+    "id" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "name" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "User_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Membership" (
+    "id" TEXT NOT NULL,
+    "orgId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "role" "Role" NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Membership_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Property" (
+    "id" TEXT NOT NULL,
+    "orgId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "address" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Property_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Unit" (
+    "id" TEXT NOT NULL,
+    "orgId" TEXT NOT NULL,
+    "propertyId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Unit_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Household" (
+    "id" TEXT NOT NULL,
+    "orgId" TEXT NOT NULL,
+    "unitId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Household_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Lease" (
+    "id" TEXT NOT NULL,
+    "orgId" TEXT NOT NULL,
+    "unitId" TEXT NOT NULL,
+    "householdId" TEXT NOT NULL,
+    "startDate" TIMESTAMP(3) NOT NULL,
+    "endDate" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Lease_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Invoice" (
+    "id" TEXT NOT NULL,
+    "orgId" TEXT NOT NULL,
+    "leaseId" TEXT NOT NULL,
+    "amount" DOUBLE PRECISION NOT NULL,
+    "dueDate" TIMESTAMP(3) NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Invoice_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Payment" (
+    "id" TEXT NOT NULL,
+    "orgId" TEXT NOT NULL,
+    "invoiceId" TEXT NOT NULL,
+    "amount" DOUBLE PRECISION NOT NULL,
+    "paidAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Payment_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Ticket" (
+    "id" TEXT NOT NULL,
+    "orgId" TEXT NOT NULL,
+    "unitId" TEXT NOT NULL,
+    "createdById" TEXT,
+    "description" TEXT NOT NULL,
+    "status" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "propertyId" TEXT,
+
+    CONSTRAINT "Ticket_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Visit" (
+    "id" TEXT NOT NULL,
+    "orgId" TEXT NOT NULL,
+    "ticketId" TEXT,
+    "propertyId" TEXT,
+    "scheduledAt" TIMESTAMP(3) NOT NULL,
+    "notes" TEXT,
+    "unitId" TEXT,
+
+    CONSTRAINT "Visit_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "UtilityReading" (
+    "id" TEXT NOT NULL,
+    "orgId" TEXT NOT NULL,
+    "unitId" TEXT NOT NULL,
+    "type" TEXT NOT NULL,
+    "reading" DOUBLE PRECISION NOT NULL,
+    "recordedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "UtilityReading_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Deposit" (
+    "id" TEXT NOT NULL,
+    "orgId" TEXT NOT NULL,
+    "leaseId" TEXT NOT NULL,
+    "amount" DOUBLE PRECISION NOT NULL,
+    "receivedAt" TIMESTAMP(3) NOT NULL,
+    "returnedAt" TIMESTAMP(3),
+
+    CONSTRAINT "Deposit_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Document" (
+    "id" TEXT NOT NULL,
+    "orgId" TEXT NOT NULL,
+    "url" TEXT NOT NULL,
+    "leaseId" TEXT,
+    "ticketId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Document_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Notification" (
+    "id" TEXT NOT NULL,
+    "orgId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "message" TEXT NOT NULL,
+    "read" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Notification_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ApiKey" (
+    "id" TEXT NOT NULL,
+    "orgId" TEXT NOT NULL,
+    "key" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "lastUsedAt" TIMESTAMP(3),
+
+    CONSTRAINT "ApiKey_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Plan" (
+    "id" TEXT NOT NULL,
+    "orgId" TEXT,
+    "name" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Plan_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "FeatureFlag" (
+    "id" TEXT NOT NULL,
+    "orgId" TEXT,
+    "name" TEXT NOT NULL,
+    "enabled" BOOLEAN NOT NULL DEFAULT false,
+
+    CONSTRAINT "FeatureFlag_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "AuditLog" (
+    "id" TEXT NOT NULL,
+    "orgId" TEXT NOT NULL,
+    "actorId" TEXT,
+    "action" TEXT NOT NULL,
+    "target" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "AuditLog_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "_HouseholdMembers" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_email_key" ON "User"("email");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ApiKey_key_key" ON "ApiKey"("key");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_HouseholdMembers_AB_unique" ON "_HouseholdMembers"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_HouseholdMembers_B_index" ON "_HouseholdMembers"("B");
+
+-- AddForeignKey
+ALTER TABLE "Membership" ADD CONSTRAINT "Membership_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Organization"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Membership" ADD CONSTRAINT "Membership_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Property" ADD CONSTRAINT "Property_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Organization"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Unit" ADD CONSTRAINT "Unit_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Organization"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Unit" ADD CONSTRAINT "Unit_propertyId_fkey" FOREIGN KEY ("propertyId") REFERENCES "Property"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Household" ADD CONSTRAINT "Household_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Organization"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Household" ADD CONSTRAINT "Household_unitId_fkey" FOREIGN KEY ("unitId") REFERENCES "Unit"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Lease" ADD CONSTRAINT "Lease_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Organization"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Lease" ADD CONSTRAINT "Lease_unitId_fkey" FOREIGN KEY ("unitId") REFERENCES "Unit"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Lease" ADD CONSTRAINT "Lease_householdId_fkey" FOREIGN KEY ("householdId") REFERENCES "Household"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Invoice" ADD CONSTRAINT "Invoice_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Organization"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Invoice" ADD CONSTRAINT "Invoice_leaseId_fkey" FOREIGN KEY ("leaseId") REFERENCES "Lease"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Payment" ADD CONSTRAINT "Payment_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Organization"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Payment" ADD CONSTRAINT "Payment_invoiceId_fkey" FOREIGN KEY ("invoiceId") REFERENCES "Invoice"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Ticket" ADD CONSTRAINT "Ticket_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Organization"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Ticket" ADD CONSTRAINT "Ticket_unitId_fkey" FOREIGN KEY ("unitId") REFERENCES "Unit"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Ticket" ADD CONSTRAINT "Ticket_createdById_fkey" FOREIGN KEY ("createdById") REFERENCES "Membership"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Ticket" ADD CONSTRAINT "Ticket_propertyId_fkey" FOREIGN KEY ("propertyId") REFERENCES "Property"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Visit" ADD CONSTRAINT "Visit_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Organization"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Visit" ADD CONSTRAINT "Visit_ticketId_fkey" FOREIGN KEY ("ticketId") REFERENCES "Ticket"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Visit" ADD CONSTRAINT "Visit_propertyId_fkey" FOREIGN KEY ("propertyId") REFERENCES "Property"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Visit" ADD CONSTRAINT "Visit_unitId_fkey" FOREIGN KEY ("unitId") REFERENCES "Unit"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "UtilityReading" ADD CONSTRAINT "UtilityReading_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Organization"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "UtilityReading" ADD CONSTRAINT "UtilityReading_unitId_fkey" FOREIGN KEY ("unitId") REFERENCES "Unit"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Deposit" ADD CONSTRAINT "Deposit_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Organization"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Deposit" ADD CONSTRAINT "Deposit_leaseId_fkey" FOREIGN KEY ("leaseId") REFERENCES "Lease"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Document" ADD CONSTRAINT "Document_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Organization"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Document" ADD CONSTRAINT "Document_leaseId_fkey" FOREIGN KEY ("leaseId") REFERENCES "Lease"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Document" ADD CONSTRAINT "Document_ticketId_fkey" FOREIGN KEY ("ticketId") REFERENCES "Ticket"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Notification" ADD CONSTRAINT "Notification_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Organization"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Notification" ADD CONSTRAINT "Notification_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ApiKey" ADD CONSTRAINT "ApiKey_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Organization"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Plan" ADD CONSTRAINT "Plan_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Organization"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "FeatureFlag" ADD CONSTRAINT "FeatureFlag_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Organization"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AuditLog" ADD CONSTRAINT "AuditLog_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Organization"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AuditLog" ADD CONSTRAINT "AuditLog_actorId_fkey" FOREIGN KEY ("actorId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_HouseholdMembers" ADD CONSTRAINT "_HouseholdMembers_A_fkey" FOREIGN KEY ("A") REFERENCES "Household"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_HouseholdMembers" ADD CONSTRAINT "_HouseholdMembers_B_fkey" FOREIGN KEY ("B") REFERENCES "Membership"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+

--- a/apps/api/prisma/migrations/migration_lock.toml
+++ b/apps/api/prisma/migrations/migration_lock.toml
@@ -1,0 +1,1 @@
+provider = "postgresql"

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -1,3 +1,6 @@
+// Prisma schema defining tenancy application data model
+// Business tables include orgId for organization scoping
+
 generator client {
   provider = "prisma-client-js"
 }
@@ -7,7 +10,243 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+enum Role {
+  landlord
+  property_manager
+  tenant
+  tradesperson
+  admin
+}
+
+model Organization {
+  id             String           @id @default(cuid())
+  name           String
+  createdAt      DateTime         @default(now())
+  memberships    Membership[]
+  properties     Property[]
+  apiKeys        ApiKey[]
+  plans          Plan[]
+  featureFlags   FeatureFlag[]
+  auditLogs      AuditLog[]
+  Unit           Unit[]
+  Household      Household[]
+  Lease          Lease[]
+  Invoice        Invoice[]
+  Payment        Payment[]
+  Ticket         Ticket[]
+  Visit          Visit[]
+  UtilityReading UtilityReading[]
+  Deposit        Deposit[]
+  Document       Document[]
+  Notification   Notification[]
+}
+
 model User {
-  id    String @id @default(cuid())
-  email String @unique
+  id            String         @id @default(cuid())
+  email         String         @unique
+  name          String?
+  createdAt     DateTime       @default(now())
+  memberships   Membership[]
+  notifications Notification[]
+  auditLogs     AuditLog[]     @relation("ActorLogs")
+}
+
+model Membership {
+  id         String       @id @default(cuid())
+  org        Organization @relation(fields: [orgId], references: [id])
+  orgId      String
+  user       User         @relation(fields: [userId], references: [id])
+  userId     String
+  role       Role
+  createdAt  DateTime     @default(now())
+  households Household[]  @relation("HouseholdMembers")
+  Ticket     Ticket[]
+}
+
+model Property {
+  id        String       @id @default(cuid())
+  org       Organization @relation(fields: [orgId], references: [id])
+  orgId     String
+  name      String
+  address   String?
+  units     Unit[]
+  visits    Visit[]
+  tickets   Ticket[]
+  createdAt DateTime     @default(now())
+}
+
+model Unit {
+  id              String           @id @default(cuid())
+  org             Organization     @relation(fields: [orgId], references: [id])
+  orgId           String
+  property        Property         @relation(fields: [propertyId], references: [id])
+  propertyId      String
+  name            String
+  households      Household[]
+  leases          Lease[]
+  utilityReadings UtilityReading[]
+  tickets         Ticket[]
+  visits          Visit[]
+  createdAt       DateTime         @default(now())
+}
+
+model Household {
+  id        String       @id @default(cuid())
+  org       Organization @relation(fields: [orgId], references: [id])
+  orgId     String
+  unit      Unit         @relation(fields: [unitId], references: [id])
+  unitId    String
+  members   Membership[] @relation("HouseholdMembers")
+  leases    Lease[]
+  createdAt DateTime     @default(now())
+}
+
+model Lease {
+  id          String       @id @default(cuid())
+  org         Organization @relation(fields: [orgId], references: [id])
+  orgId       String
+  unit        Unit         @relation(fields: [unitId], references: [id])
+  unitId      String
+  household   Household    @relation(fields: [householdId], references: [id])
+  householdId String
+  startDate   DateTime
+  endDate     DateTime?
+  invoices    Invoice[]
+  deposits    Deposit[]
+  documents   Document[]   @relation("LeaseDocuments")
+  createdAt   DateTime     @default(now())
+}
+
+model Invoice {
+  id        String       @id @default(cuid())
+  org       Organization @relation(fields: [orgId], references: [id])
+  orgId     String
+  lease     Lease        @relation(fields: [leaseId], references: [id])
+  leaseId   String
+  amount    Float
+  dueDate   DateTime
+  payments  Payment[]
+  createdAt DateTime     @default(now())
+}
+
+model Payment {
+  id        String       @id @default(cuid())
+  org       Organization @relation(fields: [orgId], references: [id])
+  orgId     String
+  invoice   Invoice      @relation(fields: [invoiceId], references: [id])
+  invoiceId String
+  amount    Float
+  paidAt    DateTime     @default(now())
+}
+
+model Ticket {
+  id          String       @id @default(cuid())
+  org         Organization @relation(fields: [orgId], references: [id])
+  orgId       String
+  unit        Unit         @relation(fields: [unitId], references: [id])
+  unitId      String
+  createdBy   Membership?  @relation(fields: [createdById], references: [id])
+  createdById String?
+  description String
+  status      String
+  visits      Visit[]
+  documents   Document[]   @relation("TicketDocuments")
+  createdAt   DateTime     @default(now())
+  Property    Property?    @relation(fields: [propertyId], references: [id])
+  propertyId  String?
+}
+
+model Visit {
+  id          String       @id @default(cuid())
+  org         Organization @relation(fields: [orgId], references: [id])
+  orgId       String
+  ticket      Ticket?      @relation(fields: [ticketId], references: [id])
+  ticketId    String?
+  property    Property?    @relation(fields: [propertyId], references: [id])
+  propertyId  String?
+  scheduledAt DateTime
+  notes       String?
+  Unit        Unit?        @relation(fields: [unitId], references: [id])
+  unitId      String?
+}
+
+model UtilityReading {
+  id         String       @id @default(cuid())
+  org        Organization @relation(fields: [orgId], references: [id])
+  orgId      String
+  unit       Unit         @relation(fields: [unitId], references: [id])
+  unitId     String
+  type       String
+  reading    Float
+  recordedAt DateTime     @default(now())
+}
+
+model Deposit {
+  id         String       @id @default(cuid())
+  org        Organization @relation(fields: [orgId], references: [id])
+  orgId      String
+  lease      Lease        @relation(fields: [leaseId], references: [id])
+  leaseId    String
+  amount     Float
+  receivedAt DateTime
+  returnedAt DateTime?
+}
+
+model Document {
+  id        String       @id @default(cuid())
+  org       Organization @relation(fields: [orgId], references: [id])
+  orgId     String
+  url       String
+  lease     Lease?       @relation("LeaseDocuments", fields: [leaseId], references: [id])
+  leaseId   String?
+  ticket    Ticket?      @relation("TicketDocuments", fields: [ticketId], references: [id])
+  ticketId  String?
+  createdAt DateTime     @default(now())
+}
+
+model Notification {
+  id        String       @id @default(cuid())
+  org       Organization @relation(fields: [orgId], references: [id])
+  orgId     String
+  user      User         @relation(fields: [userId], references: [id])
+  userId    String
+  message   String
+  read      Boolean      @default(false)
+  createdAt DateTime     @default(now())
+}
+
+model ApiKey {
+  id         String       @id @default(cuid())
+  org        Organization @relation(fields: [orgId], references: [id])
+  orgId      String
+  key        String       @unique
+  createdAt  DateTime     @default(now())
+  lastUsedAt DateTime?
+}
+
+model Plan {
+  id        String        @id @default(cuid())
+  org       Organization? @relation(fields: [orgId], references: [id])
+  orgId     String?
+  name      String
+  createdAt DateTime      @default(now())
+}
+
+model FeatureFlag {
+  id      String        @id @default(cuid())
+  org     Organization? @relation(fields: [orgId], references: [id])
+  orgId   String?
+  name    String
+  enabled Boolean       @default(false)
+}
+
+model AuditLog {
+  id        String       @id @default(cuid())
+  org       Organization @relation(fields: [orgId], references: [id])
+  orgId     String
+  actor     User?        @relation("ActorLogs", fields: [actorId], references: [id])
+  actorId   String?
+  action    String
+  target    String?
+  createdAt DateTime     @default(now())
 }

--- a/apps/api/prisma/seed.ts
+++ b/apps/api/prisma/seed.ts
@@ -1,0 +1,126 @@
+import { PrismaClient, Role } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+async function main() {
+  const org = await prisma.organization.create({
+    data: {
+      name: 'Demo Org',
+    },
+  });
+
+  // Landlord user and membership
+  await prisma.user.create({
+    data: {
+      email: 'landlord@example.com',
+      name: 'Landlord',
+      memberships: {
+        create: {
+          orgId: org.id,
+          role: Role.landlord,
+        },
+      },
+    },
+  });
+
+  // Tenants
+  const tenantInfos = [
+    { email: 'tenant1@example.com', name: 'Tenant One' },
+    { email: 'tenant2@example.com', name: 'Tenant Two' },
+    { email: 'tenant3@example.com', name: 'Tenant Three' },
+    { email: 'tenant4@example.com', name: 'Tenant Four' },
+  ];
+
+  const tenants = [] as any[];
+  for (const info of tenantInfos) {
+    const user = await prisma.user.create({
+      data: {
+        email: info.email,
+        name: info.name,
+        memberships: {
+          create: {
+            orgId: org.id,
+            role: Role.tenant,
+          },
+        },
+      },
+      include: { memberships: true },
+    });
+    tenants.push(user);
+  }
+
+  // Properties and units
+  const property1 = await prisma.property.create({
+    data: {
+      orgId: org.id,
+      name: 'Property One',
+      address: '123 Main St',
+      units: {
+        create: [
+          { orgId: org.id, name: 'Unit 1A' },
+          { orgId: org.id, name: 'Unit 1B' },
+        ],
+      },
+    },
+    include: { units: true },
+  });
+
+  const property2 = await prisma.property.create({
+    data: {
+      orgId: org.id,
+      name: 'Property Two',
+      address: '456 Side St',
+      units: {
+        create: [
+          { orgId: org.id, name: 'Unit 2A' },
+        ],
+      },
+    },
+    include: { units: true },
+  });
+
+  // Households assigning tenants to units
+  await prisma.household.create({
+    data: {
+      orgId: org.id,
+      unitId: property1.units[0].id,
+      members: {
+        connect: [
+          { id: tenants[0].memberships[0].id },
+          { id: tenants[1].memberships[0].id },
+        ],
+      },
+    },
+  });
+
+  await prisma.household.create({
+    data: {
+      orgId: org.id,
+      unitId: property1.units[1].id,
+      members: {
+        connect: [{ id: tenants[2].memberships[0].id }],
+      },
+    },
+  });
+
+  await prisma.household.create({
+    data: {
+      orgId: org.id,
+      unitId: property2.units[0].id,
+      members: {
+        connect: [{ id: tenants[3].memberships[0].id }],
+      },
+    },
+  });
+
+  console.log('Seed data created');
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -1,10 +1,12 @@
 import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { PrismaService } from './prisma.service';
+import { PropertyService } from './property/property.service';
 
 @Module({
   imports: [],
   controllers: [AppController],
-  providers: [AppService],
+  providers: [AppService, PrismaService, PropertyService],
 })
 export class AppModule {}

--- a/apps/api/src/org/org.guard.ts
+++ b/apps/api/src/org/org.guard.ts
@@ -1,0 +1,33 @@
+import { CanActivate, ExecutionContext, ForbiddenException, Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma.service';
+
+/**
+ * OrgGuard enforces that the current user has access to the requested organization.
+ * It mimics row level security by validating membership before allowing the request
+ * to proceed. The handler can rely on `req.orgId` for scoping queries.
+ */
+@Injectable()
+export class OrgGuard implements CanActivate {
+  constructor(private prisma: PrismaService) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest();
+    const orgId: string | undefined = request.params.orgId || request.body.orgId;
+    const userId: string | undefined = request.user?.id;
+
+    if (!orgId || !userId) {
+      throw new ForbiddenException('Missing organization or user information');
+    }
+
+    const membership = await this.prisma.membership.findFirst({
+      where: { orgId, userId },
+    });
+
+    if (!membership) {
+      throw new ForbiddenException('Access denied to organization');
+    }
+
+    request.orgId = orgId;
+    return true;
+  }
+}

--- a/apps/api/src/prisma.service.ts
+++ b/apps/api/src/prisma.service.ts
@@ -1,0 +1,16 @@
+import { Injectable, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
+import { PrismaClient } from '@prisma/client';
+
+@Injectable()
+export class PrismaService
+  extends PrismaClient
+  implements OnModuleInit, OnModuleDestroy
+{
+  async onModuleInit() {
+    await this.$connect();
+  }
+
+  async onModuleDestroy() {
+    await this.$disconnect();
+  }
+}

--- a/apps/api/src/property/property.service.ts
+++ b/apps/api/src/property/property.service.ts
@@ -1,0 +1,12 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma.service';
+
+/** Service demonstrating organization scoped queries. */
+@Injectable()
+export class PropertyService {
+  constructor(private prisma: PrismaService) {}
+
+  list(orgId: string) {
+    return this.prisma.property.findMany({ where: { orgId } });
+  }
+}


### PR DESCRIPTION
## Summary
- expand Prisma schema with organization-scoped tenancy models
- add org-level RLS guard and scoped property service
- provide database seed for demo organization

## Testing
- `npx prisma format`
- `npx prisma generate`
- `DATABASE_URL="postgresql://postgres:postgres@localhost:5432/tenancy" npx prisma db seed` *(fails: Can't reach database server at `localhost:5432`)*
- `npm run lint` *(fails: ESLint couldn't find the plugin "@typescript-eslint/eslint-plugin")*
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68ab4ad66204832e82471be73f49c8e4