### PR TITLE
feat(api): add tenant guard and repository base for multi-tenancy

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -3,10 +3,18 @@ import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { PrismaService } from './prisma.service';
 import { PropertyService } from './property/property.service';
+import { PropertyRepository } from './property/property.repository';
+import { TenantGuard } from './tenant.guard';
 
 @Module({
   imports: [],
   controllers: [AppController],
-  providers: [AppService, PrismaService, PropertyService],
+  providers: [
+    AppService,
+    PrismaService,
+    PropertyRepository,
+    PropertyService,
+    TenantGuard,
+  ],
 })
 export class AppModule {}

--- a/apps/api/src/common/base.repository.ts
+++ b/apps/api/src/common/base.repository.ts
@@ -1,0 +1,65 @@
+import { Inject, Injectable, Scope } from '@nestjs/common';
+import { REQUEST } from '@nestjs/core';
+import { Request } from 'express';
+import { PrismaService } from '../prisma.service';
+
+/**
+ * BaseRepository provides reusable helpers for scoping queries to the
+ * current organization and performing soft deletes. All extending
+ * repositories are request scoped so that the orgId can be resolved
+ * from the current request.
+ */
+@Injectable({ scope: Scope.REQUEST })
+export abstract class BaseRepository<T> {
+  /** Underlying Prisma model delegate (e.g. prisma.property). */
+  protected model: any;
+
+  constructor(
+    protected readonly prisma: PrismaService,
+    @Inject(REQUEST) private readonly request: Request,
+  ) {}
+
+  /** Convenience accessor for the organization id on the request. */
+  protected get orgId(): string {
+    return (this.request as any).orgId;
+  }
+
+  /** Find many records scoped to the current organization. */
+  findMany(args: any = {}) {
+    return this.model.findMany({
+      ...args,
+      where: { ...(args.where || {}), orgId: this.orgId, deletedAt: null },
+    });
+  }
+
+  /** Find a single record by id within the organization scope. */
+  findUnique(id: string, args: any = {}) {
+    return this.model.findFirst({
+      ...args,
+      where: { ...(args.where || {}), id, orgId: this.orgId, deletedAt: null },
+    });
+  }
+
+  /** Create a new record tied to the current organization. */
+  create(data: any) {
+    return this.model.create({
+      data: { ...data, orgId: this.orgId },
+    });
+  }
+
+  /** Update a record by id within the organization scope. */
+  update(id: string, data: any) {
+    return this.model.updateMany({
+      where: { id, orgId: this.orgId },
+      data,
+    });
+  }
+
+  /** Soft delete a record by setting deletedAt instead of removing. */
+  softDelete(id: string) {
+    return this.model.updateMany({
+      where: { id, orgId: this.orgId },
+      data: { deletedAt: new Date() },
+    });
+  }
+}

--- a/apps/api/src/property/property.repository.ts
+++ b/apps/api/src/property/property.repository.ts
@@ -1,0 +1,17 @@
+import { Inject, Injectable, Scope } from '@nestjs/common';
+import { REQUEST } from '@nestjs/core';
+import { Request } from 'express';
+import { PrismaService } from '../prisma.service';
+import { BaseRepository } from '../common/base.repository';
+
+/** Repository for Property model scoped by organization. */
+@Injectable({ scope: Scope.REQUEST })
+export class PropertyRepository extends BaseRepository<any> {
+  constructor(
+    prisma: PrismaService,
+    @Inject(REQUEST) request: Request,
+  ) {
+    super(prisma, request);
+    this.model = prisma.property;
+  }
+}

--- a/apps/api/src/property/property.service.ts
+++ b/apps/api/src/property/property.service.ts
@@ -1,12 +1,12 @@
-import { Injectable } from '@nestjs/common';
-import { PrismaService } from '../prisma.service';
+import { Injectable, Scope } from '@nestjs/common';
+import { PropertyRepository } from './property.repository';
 
-/** Service demonstrating organization scoped queries. */
-@Injectable()
+/** Service demonstrating organization scoped queries using BaseRepository. */
+@Injectable({ scope: Scope.REQUEST })
 export class PropertyService {
-  constructor(private prisma: PrismaService) {}
+  constructor(private readonly repo: PropertyRepository) {}
 
-  list(orgId: string) {
-    return this.prisma.property.findMany({ where: { orgId } });
+  list() {
+    return this.repo.findMany();
   }
 }

--- a/apps/api/src/tenant.guard.ts
+++ b/apps/api/src/tenant.guard.ts
@@ -1,0 +1,22 @@
+import { CanActivate, ExecutionContext, ForbiddenException, Injectable } from '@nestjs/common';
+
+/**
+ * TenantGuard extracts the organization id from the authenticated user's JWT
+ * and attaches it to the request object. Repositories can then automatically
+ * scope their queries to the current organization.
+ */
+@Injectable()
+export class TenantGuard implements CanActivate {
+  canActivate(context: ExecutionContext): boolean {
+    const request = context.switchToHttp().getRequest();
+    const orgId = request.user?.orgId;
+
+    if (!orgId) {
+      throw new ForbiddenException('Organization missing in token');
+    }
+
+    // make orgId available to downstream providers and repositories
+    request.orgId = orgId;
+    return true;
+  }
+}


### PR DESCRIPTION
## Summary
- implement TenantGuard to read org id from JWT and inject into request
- add BaseRepository with orgId scoping and soft delete helpers
- add PropertyRepository and adapt service for tenant-aware queries
- register new providers in AppModule

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: turbo: not found)*


------
https://chatgpt.com/codex/tasks/task_e_68ab4d254288832e9a4e63be82114059