### PR TITLE
feat: add basic nextauth authentication

### DIFF
--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -45,10 +45,51 @@ model User {
   id            String         @id @default(cuid())
   email         String         @unique
   name          String?
+  password      String?
+  emailVerified DateTime?
+  image         String?
+  totpSecret    String?
+  totpEnabled   Boolean        @default(false)
   createdAt     DateTime       @default(now())
   memberships   Membership[]
   notifications Notification[]
   auditLogs     AuditLog[]     @relation("ActorLogs")
+  accounts      Account[]
+  sessions      Session[]
+}
+
+model Account {
+  id                String  @id @default(cuid())
+  user              User    @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId            String
+  type              String
+  provider          String
+  providerAccountId String
+  refresh_token     String? @db.Text
+  access_token      String? @db.Text
+  expires_at        Int?
+  token_type        String?
+  scope             String?
+  id_token          String? @db.Text
+  session_state     String?
+
+  @@unique([provider, providerAccountId])
+}
+
+model Session {
+  id           String   @id @default(cuid())
+  sessionToken String   @unique
+  user         User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId       String
+  expires      DateTime
+}
+
+model VerificationToken {
+  identifier String
+  token      String   @unique
+  expires    DateTime
+
+  @@unique([identifier, token])
 }
 
 model Membership {

--- a/apps/web/app/(auth)/mfa/setup/page.tsx
+++ b/apps/web/app/(auth)/mfa/setup/page.tsx
@@ -1,0 +1,40 @@
+'use client';
+import { useEffect, useState } from 'react';
+import QRCode from 'qrcode';
+
+export default function MfaSetupPage() {
+  const [qr, setQr] = useState('');
+  const [secret, setSecret] = useState('');
+  const [code, setCode] = useState('');
+
+  useEffect(() => {
+    fetch('/api/auth/mfa/setup', { method: 'POST' })
+      .then(res => res.json())
+      .then(async data => {
+        setSecret(data.secret);
+        const img = await QRCode.toDataURL(data.otpauthUrl);
+        setQr(img);
+      });
+  }, []);
+
+  async function handleVerify(e: React.FormEvent) {
+    e.preventDefault();
+    await fetch('/api/auth/mfa/verify', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ code }),
+    });
+  }
+
+  return (
+    <div>
+      <h1>MFA Setup</h1>
+      {qr && <img src={qr} alt="QR Code" />}
+      <p>Secret: {secret}</p>
+      <form onSubmit={handleVerify}>
+        <input value={code} onChange={e => setCode(e.target.value)} placeholder="Code" />
+        <button type="submit">Verify</button>
+      </form>
+    </div>
+  );
+}

--- a/apps/web/app/(auth)/mfa/verify/page.tsx
+++ b/apps/web/app/(auth)/mfa/verify/page.tsx
@@ -1,0 +1,25 @@
+'use client';
+import { useState } from 'react';
+
+export default function MfaVerifyPage() {
+  const [code, setCode] = useState('');
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    await fetch('/api/auth/mfa/verify', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ code }),
+    });
+  }
+
+  return (
+    <div>
+      <h1>MFA Verification</h1>
+      <form onSubmit={handleSubmit}>
+        <input value={code} onChange={e => setCode(e.target.value)} placeholder="Code" />
+        <button type="submit">Verify</button>
+      </form>
+    </div>
+  );
+}

--- a/apps/web/app/(auth)/reset-password/page.tsx
+++ b/apps/web/app/(auth)/reset-password/page.tsx
@@ -1,0 +1,25 @@
+'use client';
+import { useState } from 'react';
+
+export default function ResetPasswordPage() {
+  const [email, setEmail] = useState('');
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    await fetch('/api/auth/reset-password', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email }),
+    });
+  }
+
+  return (
+    <div>
+      <h1>Reset Password</h1>
+      <form onSubmit={handleSubmit}>
+        <input type="email" value={email} onChange={e => setEmail(e.target.value)} placeholder="Email" />
+        <button type="submit">Send Reset Link</button>
+      </form>
+    </div>
+  );
+}

--- a/apps/web/app/(auth)/signin/page.tsx
+++ b/apps/web/app/(auth)/signin/page.tsx
@@ -1,0 +1,24 @@
+'use client';
+import { signIn } from 'next-auth/react';
+import { useState } from 'react';
+
+export default function SignInPage() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    await signIn('credentials', { email, password, callbackUrl: '/' });
+  }
+
+  return (
+    <div>
+      <h1>Sign In</h1>
+      <form onSubmit={handleSubmit}>
+        <input type="email" value={email} onChange={e => setEmail(e.target.value)} placeholder="Email" />
+        <input type="password" value={password} onChange={e => setPassword(e.target.value)} placeholder="Password" />
+        <button type="submit">Sign In</button>
+      </form>
+    </div>
+  );
+}

--- a/apps/web/app/(auth)/signup/page.tsx
+++ b/apps/web/app/(auth)/signup/page.tsx
@@ -1,0 +1,30 @@
+'use client';
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+export default function SignUpPage() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const router = useRouter();
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    await fetch('/api/auth/signup', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, password }),
+    });
+    router.push('/signin');
+  }
+
+  return (
+    <div>
+      <h1>Sign Up</h1>
+      <form onSubmit={handleSubmit}>
+        <input type="email" value={email} onChange={e => setEmail(e.target.value)} placeholder="Email" />
+        <input type="password" value={password} onChange={e => setPassword(e.target.value)} placeholder="Password" />
+        <button type="submit">Create Account</button>
+      </form>
+    </div>
+  );
+}

--- a/apps/web/app/(auth)/verify-email/page.tsx
+++ b/apps/web/app/(auth)/verify-email/page.tsx
@@ -1,0 +1,21 @@
+'use client';
+import { useSearchParams } from 'next/navigation';
+import { useEffect, useState } from 'react';
+
+export default function VerifyEmailPage() {
+  const params = useSearchParams();
+  const token = params.get('token');
+  const [status, setStatus] = useState('Verifying...');
+
+  useEffect(() => {
+    if (token) {
+      fetch('/api/auth/verify-email', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ token }),
+      }).then(() => setStatus('Email verified')); 
+    }
+  }, [token]);
+
+  return <p>{status}</p>;
+}

--- a/apps/web/app/api/auth/[...nextauth]/route.ts
+++ b/apps/web/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,6 @@
+import NextAuth from 'next-auth';
+import { authOptions } from '@/lib/auth';
+
+const handler = NextAuth(authOptions);
+
+export { handler as GET, handler as POST };

--- a/apps/web/app/api/auth/mfa/setup/route.ts
+++ b/apps/web/app/api/auth/mfa/setup/route.ts
@@ -1,0 +1,18 @@
+import { prisma } from '@/lib/prisma';
+import { NextResponse } from 'next/server';
+import speakeasy from 'speakeasy';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+
+export async function POST() {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const secret = speakeasy.generateSecret({ name: 'Tenancy App' });
+  await prisma.user.update({
+    where: { id: (session.user as any).id },
+    data: { totpSecret: secret.base32, totpEnabled: false },
+  });
+  return NextResponse.json({ secret: secret.base32, otpauthUrl: secret.otpauth_url });
+}

--- a/apps/web/app/api/auth/mfa/verify/route.ts
+++ b/apps/web/app/api/auth/mfa/verify/route.ts
@@ -1,0 +1,26 @@
+import { prisma } from '@/lib/prisma';
+import { NextResponse } from 'next/server';
+import speakeasy from 'speakeasy';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+
+export async function POST(req: Request) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const { code } = await req.json();
+  const user = await prisma.user.findUnique({ where: { id: (session.user as any).id } });
+  if (!user?.totpSecret) {
+    return NextResponse.json({ error: 'No secret' }, { status: 400 });
+  }
+  const verified = speakeasy.totp.verify({
+    secret: user.totpSecret,
+    encoding: 'base32',
+    token: code,
+  });
+  if (verified) {
+    await prisma.user.update({ where: { id: user.id }, data: { totpEnabled: true } });
+  }
+  return NextResponse.json({ verified });
+}

--- a/apps/web/app/api/auth/reset-password/route.ts
+++ b/apps/web/app/api/auth/reset-password/route.ts
@@ -1,0 +1,6 @@
+import { NextResponse } from 'next/server';
+
+export async function POST(req: Request) {
+  // TODO: implement password reset email
+  return NextResponse.json({ ok: true });
+}

--- a/apps/web/app/api/auth/signup/route.ts
+++ b/apps/web/app/api/auth/signup/route.ts
@@ -1,0 +1,18 @@
+import { prisma } from '@/lib/prisma';
+import { hash } from 'bcryptjs';
+import { NextResponse } from 'next/server';
+
+export async function POST(req: Request) {
+  const { email, password } = await req.json();
+  if (!email || !password) {
+    return NextResponse.json({ error: 'Email and password required' }, { status: 400 });
+  }
+  const existing = await prisma.user.findUnique({ where: { email } });
+  if (existing) {
+    return NextResponse.json({ error: 'Email already in use' }, { status: 400 });
+  }
+  const hashed = await hash(password, 10);
+  const user = await prisma.user.create({ data: { email, password: hashed } });
+  // TODO: send verification email
+  return NextResponse.json({ id: user.id, email: user.email });
+}

--- a/apps/web/app/api/auth/verify-email/route.ts
+++ b/apps/web/app/api/auth/verify-email/route.ts
@@ -1,0 +1,14 @@
+import { prisma } from '@/lib/prisma';
+import { NextResponse } from 'next/server';
+
+export async function POST(req: Request) {
+  const { token } = await req.json();
+  // Placeholder verification using VerificationToken table
+  const record = await prisma.verificationToken.findUnique({ where: { token } });
+  if (!record || record.expires < new Date()) {
+    return NextResponse.json({ error: 'Invalid token' }, { status: 400 });
+  }
+  await prisma.user.update({ where: { email: record.identifier }, data: { emailVerified: new Date() } });
+  await prisma.verificationToken.delete({ where: { token } });
+  return NextResponse.json({ ok: true });
+}

--- a/apps/web/lib/auth.ts
+++ b/apps/web/lib/auth.ts
@@ -1,0 +1,40 @@
+import { PrismaAdapter } from '@next-auth/prisma-adapter';
+import CredentialsProvider from 'next-auth/providers/credentials';
+import GoogleProvider from 'next-auth/providers/google';
+import { prisma } from './prisma';
+import { compare } from 'bcryptjs';
+import type { NextAuthOptions } from 'next-auth';
+
+export const authOptions: NextAuthOptions = {
+  adapter: PrismaAdapter(prisma),
+  session: { strategy: 'jwt' },
+  providers: [
+    GoogleProvider({
+      clientId: process.env.GOOGLE_CLIENT_ID || '',
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET || '',
+    }),
+    CredentialsProvider({
+      name: 'Credentials',
+      credentials: {
+        email: { label: 'Email', type: 'email' },
+        password: { label: 'Password', type: 'password' },
+      },
+      async authorize(credentials) {
+        if (!credentials?.email || !credentials.password) return null;
+        const user = await prisma.user.findUnique({ where: { email: credentials.email } });
+        if (!user?.password) return null;
+        const isValid = await compare(credentials.password, user.password);
+        if (!isValid) return null;
+        return { id: user.id, email: user.email, name: user.name } as any;
+      },
+    }),
+  ],
+  callbacks: {
+    async session({ session, token }) {
+      if (token.sub && session.user) {
+        (session.user as any).id = token.sub;
+      }
+      return session;
+    },
+  },
+};

--- a/apps/web/lib/prisma.ts
+++ b/apps/web/lib/prisma.ts
@@ -1,0 +1,9 @@
+import { PrismaClient } from '@prisma/client';
+
+const globalForPrisma = global as unknown as { prisma: PrismaClient };
+
+export const prisma =
+  globalForPrisma.prisma ||
+  new PrismaClient();
+
+if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -19,13 +19,20 @@
     "@tenancy/ui": "workspace:*",
     "@tenancy/types": "workspace:*",
     "@tenancy/config": "workspace:*",
-    "@shadcn/ui": "^0.9.1"
+    "@shadcn/ui": "^0.9.1",
+    "next-auth": "^4.22.1",
+    "@next-auth/prisma-adapter": "^1.0.7",
+    "@prisma/client": "^5.4.1",
+    "bcryptjs": "^2.4.3",
+    "speakeasy": "^2.0.0",
+    "qrcode": "^1.5.3"
   },
   "devDependencies": {
     "typescript": "^5.3.0",
     "eslint": "^8.50.0",
     "tailwindcss": "^3.3.3",
     "autoprefixer": "^10.4.14",
-    "postcss": "^8.4.27"
+    "postcss": "^8.4.27",
+    "prisma": "^5.4.1"
   }
 }

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules"]

--- a/apps/web/types/next-auth.d.ts
+++ b/apps/web/types/next-auth.d.ts
@@ -1,0 +1,11 @@
+import 'next-auth';
+
+declare module 'next-auth' {
+  interface Session {
+    user?: {
+      id: string;
+      email?: string | null;
+      name?: string | null;
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- integrate NextAuth with credentials and Google providers
- scaffold auth pages including sign-in, sign-up, reset password, email verification, and MFA
- extend Prisma schema and setup MFA endpoints

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68ab536da878832e9b1f6c500d5a50c3