### PR TITLE
feat: add property and unit management with S3 uploads

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -17,6 +17,8 @@
     "@nestjs/jwt": "^11.0.0",
     "@nestjs/passport": "^11.0.5",
     "@prisma/client": "^5.4.1",
+    "@aws-sdk/client-s3": "^3.454.0",
+    "@aws-sdk/s3-request-presigner": "^3.454.0",
     "passport": "^0.6.0",
     "passport-google-oauth20": "^2.0.0",
     "passport-jwt": "^4.0.1",

--- a/apps/api/prisma/migrations/002_add_image_deleted/migration.sql
+++ b/apps/api/prisma/migrations/002_add_image_deleted/migration.sql
@@ -1,0 +1,7 @@
+-- AlterTable
+ALTER TABLE "Property" ADD COLUMN "imageUrl" TEXT,
+                           ADD COLUMN "deletedAt" TIMESTAMP(3);
+
+-- AlterTable
+ALTER TABLE "Unit" ADD COLUMN "imageUrl" TEXT,
+                     ADD COLUMN "deletedAt" TIMESTAMP(3);

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -114,6 +114,8 @@ model Property {
   visits    Visit[]
   tickets   Ticket[]
   createdAt DateTime     @default(now())
+  imageUrl  String?
+  deletedAt DateTime?
 }
 
 model Unit {
@@ -129,6 +131,8 @@ model Unit {
   tickets         Ticket[]
   visits          Visit[]
   createdAt       DateTime         @default(now())
+  imageUrl        String?
+  deletedAt       DateTime?
 }
 
 model Household {

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -4,17 +4,25 @@ import { AppService } from './app.service';
 import { PrismaService } from './prisma.service';
 import { PropertyService } from './property/property.service';
 import { PropertyRepository } from './property/property.repository';
+import { PropertyController } from './property/property.controller';
 import { TenantGuard } from './tenant.guard';
 import { AuthModule } from './auth/auth.module';
+import { S3Service } from './s3.service';
+import { UnitRepository } from './unit/unit.repository';
+import { UnitService } from './unit/unit.service';
+import { UnitController } from './unit/unit.controller';
 
 @Module({
   imports: [AuthModule],
-  controllers: [AppController],
+  controllers: [AppController, PropertyController, UnitController],
   providers: [
     AppService,
     PrismaService,
+    S3Service,
     PropertyRepository,
     PropertyService,
+    UnitRepository,
+    UnitService,
     TenantGuard,
   ],
 })

--- a/apps/api/src/property/property.controller.ts
+++ b/apps/api/src/property/property.controller.ts
@@ -1,0 +1,64 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
+} from '@nestjs/common';
+import { z } from 'zod';
+import { ApiTags } from '@nestjs/swagger';
+import { PropertyService } from './property.service';
+
+const PropertyCreate = z.object({
+  name: z.string(),
+  address: z.string().optional(),
+});
+
+const PropertyUpdate = PropertyCreate.partial();
+
+const UploadPhoto = z.object({
+  filename: z.string(),
+  contentType: z.string(),
+});
+
+@ApiTags('properties')
+@Controller('properties')
+export class PropertyController {
+  constructor(private readonly service: PropertyService) {}
+
+  @Get()
+  list() {
+    return this.service.list();
+  }
+
+  @Get(':id')
+  get(@Param('id') id: string) {
+    return this.service.get(id);
+  }
+
+  @Post()
+  create(@Body() body: any) {
+    const data = PropertyCreate.parse(body);
+    return this.service.create(data);
+  }
+
+  @Patch(':id')
+  update(@Param('id') id: string, @Body() body: any) {
+    const data = PropertyUpdate.parse(body);
+    return this.service.update(id, data);
+  }
+
+  @Delete(':id')
+  delete(@Param('id') id: string) {
+    return this.service.delete(id);
+  }
+
+  @Post(':id/photo')
+  uploadPhoto(@Param('id') id: string, @Body() body: any) {
+    const { filename, contentType } = UploadPhoto.parse(body);
+    return this.service.createPhotoUpload(id, filename, contentType);
+  }
+}
+

--- a/apps/api/src/s3.service.ts
+++ b/apps/api/src/s3.service.ts
@@ -1,0 +1,43 @@
+import { Injectable } from '@nestjs/common';
+import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+
+/** Simple S3 helper for generating signed upload URLs. */
+@Injectable()
+export class S3Service {
+  private readonly client: S3Client;
+  private readonly bucket = process.env.S3_BUCKET || 'tenancy';
+
+  constructor() {
+    this.client = new S3Client({
+      region: process.env.AWS_REGION || 'us-east-1',
+      endpoint: process.env.S3_ENDPOINT,
+      forcePathStyle: !!process.env.S3_ENDPOINT,
+      credentials: {
+        accessKeyId: process.env.AWS_ACCESS_KEY_ID || 'test',
+        secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY || 'test',
+      },
+    });
+  }
+
+  /** Generate a presigned URL for uploading to the given key. */
+  async getSignedUploadUrl(key: string, contentType: string) {
+    const command = new PutObjectCommand({
+      Bucket: this.bucket,
+      Key: key,
+      ContentType: contentType,
+    });
+    const uploadUrl = await getSignedUrl(this.client, command, {
+      expiresIn: 3600,
+    });
+    return { uploadUrl, url: this.getPublicUrl(key), key };
+  }
+
+  /** Public URL for an object. */
+  getPublicUrl(key: string) {
+    const base =
+      process.env.S3_PUBLIC_URL || `https://${this.bucket}.s3.amazonaws.com`;
+    return `${base}/${key}`;
+  }
+}
+

--- a/apps/api/src/unit/unit.controller.ts
+++ b/apps/api/src/unit/unit.controller.ts
@@ -1,0 +1,65 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
+  Query,
+} from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import { z } from 'zod';
+import { UnitService } from './unit.service';
+
+const UnitCreate = z.object({
+  name: z.string(),
+  propertyId: z.string(),
+});
+
+const UnitUpdate = UnitCreate.partial();
+
+const UploadPhoto = z.object({
+  filename: z.string(),
+  contentType: z.string(),
+});
+
+@ApiTags('units')
+@Controller('units')
+export class UnitController {
+  constructor(private readonly service: UnitService) {}
+
+  @Get()
+  list(@Query('propertyId') propertyId: string) {
+    return this.service.list(propertyId);
+  }
+
+  @Get(':id')
+  get(@Param('id') id: string) {
+    return this.service.get(id);
+  }
+
+  @Post()
+  create(@Body() body: any) {
+    const data = UnitCreate.parse(body);
+    return this.service.create(data);
+  }
+
+  @Patch(':id')
+  update(@Param('id') id: string, @Body() body: any) {
+    const data = UnitUpdate.parse(body);
+    return this.service.update(id, data);
+  }
+
+  @Delete(':id')
+  delete(@Param('id') id: string) {
+    return this.service.delete(id);
+  }
+
+  @Post(':id/photo')
+  uploadPhoto(@Param('id') id: string, @Body() body: any) {
+    const { filename, contentType } = UploadPhoto.parse(body);
+    return this.service.createPhotoUpload(id, filename, contentType);
+  }
+}
+

--- a/apps/api/src/unit/unit.repository.ts
+++ b/apps/api/src/unit/unit.repository.ts
@@ -1,0 +1,17 @@
+import { Inject, Injectable, Scope } from '@nestjs/common';
+import { REQUEST } from '@nestjs/core';
+import { Request } from 'express';
+import { PrismaService } from '../prisma.service';
+import { BaseRepository } from '../common/base.repository';
+
+@Injectable({ scope: Scope.REQUEST })
+export class UnitRepository extends BaseRepository<any> {
+  constructor(
+    prisma: PrismaService,
+    @Inject(REQUEST) request: Request,
+  ) {
+    super(prisma, request);
+    this.model = prisma.unit;
+  }
+}
+

--- a/apps/api/src/unit/unit.service.ts
+++ b/apps/api/src/unit/unit.service.ts
@@ -1,23 +1,23 @@
 import { Injectable, Scope } from '@nestjs/common';
-import { PropertyRepository } from './property.repository';
+import { UnitRepository } from './unit.repository';
 import { S3Service } from '../s3.service';
 
 @Injectable({ scope: Scope.REQUEST })
-export class PropertyService {
+export class UnitService {
   constructor(
-    private readonly repo: PropertyRepository,
+    private readonly repo: UnitRepository,
     private readonly s3: S3Service,
   ) {}
 
-  list() {
-    return this.repo.findMany({ include: { units: true } });
+  list(propertyId: string) {
+    return this.repo.findMany({ where: { propertyId } });
   }
 
   get(id: string) {
-    return this.repo.findUnique(id, { include: { units: true } });
+    return this.repo.findUnique(id);
   }
 
-  create(data: { name: string; address?: string }) {
+  create(data: { name: string; propertyId: string }) {
     return this.repo.create(data);
   }
 
@@ -30,9 +30,10 @@ export class PropertyService {
   }
 
   async createPhotoUpload(id: string, filename: string, contentType: string) {
-    const key = `properties/${id}/${Date.now()}-${filename}`;
+    const key = `units/${id}/${Date.now()}-${filename}`;
     const signed = await this.s3.getSignedUploadUrl(key, contentType);
     await this.repo.update(id, { imageUrl: signed.url });
     return signed;
   }
 }
+

--- a/apps/web/app/properties/[id]/page.tsx
+++ b/apps/web/app/properties/[id]/page.tsx
@@ -1,0 +1,38 @@
+import { ImageUploader } from '@/components/ImageUploader';
+
+async function fetchProperty(id: string) {
+  const res = await fetch(
+    `${process.env.NEXT_PUBLIC_API_URL}/properties/${id}`,
+    { cache: 'no-store' },
+  );
+  return res.json();
+}
+
+interface Props {
+  params: { id: string };
+}
+
+export default async function PropertyDetail({ params }: Props) {
+  const property = await fetchProperty(params.id);
+  return (
+    <div>
+      <h1>{property.name}</h1>
+      {property.imageUrl && (
+        <img src={property.imageUrl} alt={property.name} className="max-w-sm" />
+      )}
+      <ImageUploader
+        uploadUrlEndpoint={`${process.env.NEXT_PUBLIC_API_URL}/properties/${property.id}/photo`}
+      />
+
+      <h2>Units</h2>
+      <ul>
+        {property.units?.map((u: any) => (
+          <li key={u.id}>
+            <a href={`/units/${u.id}`}>{u.name}</a>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+

--- a/apps/web/app/properties/page.tsx
+++ b/apps/web/app/properties/page.tsx
@@ -1,0 +1,24 @@
+async function fetchProperties() {
+  const res = await fetch(
+    `${process.env.NEXT_PUBLIC_API_URL}/properties`,
+    { cache: 'no-store' },
+  );
+  return res.json();
+}
+
+export default async function PropertiesPage() {
+  const properties = await fetchProperties();
+  return (
+    <div>
+      <h1>Properties</h1>
+      <ul>
+        {properties.map((p: any) => (
+          <li key={p.id}>
+            <a href={`/properties/${p.id}`}>{p.name}</a>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+

--- a/apps/web/app/units/[id]/page.tsx
+++ b/apps/web/app/units/[id]/page.tsx
@@ -1,0 +1,29 @@
+import { ImageUploader } from '@/components/ImageUploader';
+
+async function fetchUnit(id: string) {
+  const res = await fetch(
+    `${process.env.NEXT_PUBLIC_API_URL}/units/${id}`,
+    { cache: 'no-store' },
+  );
+  return res.json();
+}
+
+interface Props {
+  params: { id: string };
+}
+
+export default async function UnitDetail({ params }: Props) {
+  const unit = await fetchUnit(params.id);
+  return (
+    <div>
+      <h1>{unit.name}</h1>
+      {unit.imageUrl && (
+        <img src={unit.imageUrl} alt={unit.name} className="max-w-sm" />
+      )}
+      <ImageUploader
+        uploadUrlEndpoint={`${process.env.NEXT_PUBLIC_API_URL}/units/${unit.id}/photo`}
+      />
+    </div>
+  );
+}
+

--- a/apps/web/components/ImageUploader.tsx
+++ b/apps/web/components/ImageUploader.tsx
@@ -1,0 +1,43 @@
+'use client';
+import { useState } from 'react';
+
+interface Props {
+  /** API endpoint that returns a signed upload URL. */
+  uploadUrlEndpoint: string;
+  onUploaded?: (url: string) => void;
+}
+
+export function ImageUploader({ uploadUrlEndpoint, onUploaded }: Props) {
+  const [uploading, setUploading] = useState(false);
+  const [url, setUrl] = useState<string>();
+
+  async function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    setUploading(true);
+    const res = await fetch(uploadUrlEndpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ filename: file.name, contentType: file.type }),
+    });
+    const { uploadUrl, url: publicUrl } = await res.json();
+    await fetch(uploadUrl, {
+      method: 'PUT',
+      headers: { 'Content-Type': file.type },
+      body: file,
+    });
+    setUrl(publicUrl);
+    setUploading(false);
+    onUploaded?.(publicUrl);
+  }
+
+  return (
+    <div>
+      <input type="file" onChange={handleChange} />
+      {uploading && <p>Uploading...</p>}
+      {url && <img src={url} alt="uploaded" className="max-w-xs" />}
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add property and unit CRUD endpoints with zod validation and S3 photo uploads
- expose property/unit pages in web app with image uploader using signed URLs
- update prisma schema for image/deleted fields

## Testing
- `npm --prefix apps/api run lint` *(fails: ESLint couldn't find an eslint.config file)*
- `npm --prefix apps/api run typecheck` *(fails: Cannot find module '@nestjs/common', etc.)*
- `npm --prefix apps/web run lint` *(fails: next: not found)*
- `npm --prefix apps/web run typecheck` *(fails: Cannot find module 'react', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68aba1e2ac50832eb0577768b958bcea