### PR TITLE
feat: add property CSV import/export

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -5,6 +5,7 @@ import { PrismaService } from './prisma.service';
 import { PropertyService } from './property/property.service';
 import { PropertyRepository } from './property/property.repository';
 import { PropertyController } from './property/property.controller';
+import { PropertyImportExportController } from './property/property-import-export.controller';
 import { TenantGuard } from './tenant.guard';
 import { AuthModule } from './auth/auth.module';
 import { S3Service } from './s3.service';
@@ -14,7 +15,12 @@ import { UnitController } from './unit/unit.controller';
 
 @Module({
   imports: [AuthModule],
-  controllers: [AppController, PropertyController, UnitController],
+  controllers: [
+    AppController,
+    PropertyController,
+    UnitController,
+    PropertyImportExportController,
+  ],
   providers: [
     AppService,
     PrismaService,

--- a/apps/api/src/property/property-import-export.controller.ts
+++ b/apps/api/src/property/property-import-export.controller.ts
@@ -1,0 +1,27 @@
+import { Controller, Post, Get, UploadedFile, UseInterceptors, Query, Res } from '@nestjs/common';
+import { FileInterceptor } from '@nestjs/platform-express';
+import { PropertyService } from './property.service';
+import { Response } from 'express';
+
+@Controller()
+export class PropertyImportExportController {
+  constructor(private readonly service: PropertyService) {}
+
+  @Post('properties:import')
+  @UseInterceptors(FileInterceptor('file'))
+  async importCsv(
+    @UploadedFile() file: Express.Multer.File,
+    @Query('commit') commit?: string,
+  ) {
+    const text = file.buffer.toString();
+    return this.service.importCsv(text, commit === 'true');
+  }
+
+  @Get('properties:export')
+  async exportCsv(@Res() res: Response) {
+    const csv = await this.service.exportCsv();
+    res.setHeader('Content-Type', 'text/csv');
+    res.setHeader('Content-Disposition', 'attachment; filename="properties.csv"');
+    res.send(csv);
+  }
+}

--- a/apps/api/src/property/property.service.ts
+++ b/apps/api/src/property/property.service.ts
@@ -1,12 +1,14 @@
 import { Injectable, Scope } from '@nestjs/common';
 import { PropertyRepository } from './property.repository';
 import { S3Service } from '../s3.service';
+import { UnitRepository } from '../unit/unit.repository';
 
 @Injectable({ scope: Scope.REQUEST })
 export class PropertyService {
   constructor(
     private readonly repo: PropertyRepository,
     private readonly s3: S3Service,
+    private readonly unitRepo: UnitRepository,
   ) {}
 
   list() {
@@ -34,5 +36,83 @@ export class PropertyService {
     const signed = await this.s3.getSignedUploadUrl(key, contentType);
     await this.repo.update(id, { imageUrl: signed.url });
     return signed;
+  }
+
+  /** Convert properties and units to CSV string. */
+  async exportCsv() {
+    const properties = await this.repo.findMany({ include: { units: true } });
+    const lines = ['propertyName,propertyAddress,unitName'];
+    for (const p of properties) {
+      if (p.units.length === 0) {
+        lines.push(`${this.escape(p.name)},${this.escape(p.address || '')},`);
+      }
+      for (const u of p.units) {
+        lines.push(
+          `${this.escape(p.name)},${this.escape(p.address || '')},${this.escape(u.name)}`,
+        );
+      }
+    }
+    return lines.join('\n');
+  }
+
+  /** Import properties and units from CSV. */
+  async importCsv(csv: string, commit = false) {
+    const { headers, rows } = this.parseCsv(csv);
+    const required = ['propertyName', 'unitName'];
+    const missing = required.filter((h) => !headers.includes(h));
+    if (missing.length) {
+      return { preview: [], errors: [{ row: 1, message: `Missing headers: ${missing.join(', ')}` }] };
+    }
+
+    const errors: any[] = [];
+    const valid: any[] = [];
+    rows.forEach((row, idx) => {
+      if (!row.propertyName || !row.unitName) {
+        errors.push({ row: idx + 2, message: 'propertyName and unitName are required' });
+      } else {
+        valid.push(row);
+      }
+    });
+
+    if (!commit) {
+      return { preview: valid, errors };
+    }
+
+    const propertyMap = new Map<string, any>();
+    for (const row of valid) {
+      let property = propertyMap.get(row.propertyName);
+      if (!property) {
+        property = await this.repo.create({
+          name: row.propertyName,
+          address: row.propertyAddress || undefined,
+        });
+        propertyMap.set(row.propertyName, property);
+      }
+      await this.unitRepo.create({ name: row.unitName, propertyId: property.id });
+    }
+
+    return { imported: valid.length, errors };
+  }
+
+  private parseCsv(text: string) {
+    const lines = text.trim().split(/\r?\n/);
+    const headers = lines.shift()?.split(',') || [];
+    const rows = lines
+      .filter((l) => l.trim().length > 0)
+      .map((line) => {
+        const values = line.split(',');
+        const row: any = {};
+        headers.forEach((h, i) => (row[h] = values[i] || ''));
+        return row;
+      });
+    return { headers, rows };
+  }
+
+  private escape(value: string) {
+    if (value === undefined || value === null) return '';
+    if (/[",\n]/.test(value)) {
+      return '"' + value.replace(/"/g, '""') + '"';
+    }
+    return value;
   }
 }

--- a/apps/web/app/properties/import/page.tsx
+++ b/apps/web/app/properties/import/page.tsx
@@ -1,0 +1,128 @@
+'use client';
+import { useState } from 'react';
+
+export default function ImportPropertiesPage() {
+  const [file, setFile] = useState<File | null>(null);
+  const [errors, setErrors] = useState<any[]>([]);
+  const [preview, setPreview] = useState<any[]>([]);
+  const [success, setSuccess] = useState(false);
+
+  const upload = async (f: File) => {
+    const form = new FormData();
+    form.append('file', f);
+    const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/properties:import`, {
+      method: 'POST',
+      body: form,
+    });
+    const data = await res.json();
+    setErrors(data.errors || []);
+    setPreview(data.preview || []);
+  };
+
+  const handleDrop = async (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    const f = e.dataTransfer.files?.[0];
+    if (f) {
+      setFile(f);
+      await upload(f);
+    }
+  };
+
+  const handleFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const f = e.target.files?.[0];
+    if (f) {
+      setFile(f);
+      await upload(f);
+    }
+  };
+
+  const commit = async () => {
+    if (!file) return;
+    const form = new FormData();
+    form.append('file', file);
+    const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/properties:import?commit=true`, {
+      method: 'POST',
+      body: form,
+    });
+    if (res.ok) {
+      setSuccess(true);
+      setPreview([]);
+      setErrors([]);
+    }
+  };
+
+  return (
+    <div>
+      <h1>Import Properties</h1>
+      <div
+        onDragOver={(e) => e.preventDefault()}
+        onDrop={handleDrop}
+        style={{ border: '2px dashed #ccc', padding: '20px', textAlign: 'center' }}
+      >
+        {file ? file.name : 'Drag & Drop CSV here or click to select'}
+        <input type="file" accept=".csv" onChange={handleFile} style={{ display: 'none' }} id="fileInput" />
+        <label htmlFor="fileInput" style={{ cursor: 'pointer', display: 'block', marginTop: '10px' }}>
+          Browse
+        </label>
+      </div>
+      {errors.length > 0 && (
+        <table>
+          <thead>
+            <tr>
+              <th>Row</th>
+              <th>Error</th>
+            </tr>
+          </thead>
+          <tbody>
+            {errors.map((e, i) => (
+              <tr key={i}>
+                <td>{e.row}</td>
+                <td>{e.message}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+      {preview.length > 0 && errors.length === 0 && (
+        <div>
+          <h2>Preview</h2>
+          <table>
+            <thead>
+              <tr>
+                {Object.keys(preview[0]).map((h) => (
+                  <th key={h}>{h}</th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {preview.map((row, i) => (
+                <tr key={i}>
+                  {Object.keys(row).map((h) => (
+                    <td key={h}>{row[h]}</td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          <button onClick={commit} style={{ marginTop: '1rem' }}>
+            Import
+          </button>
+        </div>
+      )}
+      {success && (
+        <div
+          style={{
+            position: 'fixed',
+            bottom: '1rem',
+            right: '1rem',
+            background: '#48bb78',
+            color: '#fff',
+            padding: '10px',
+          }}
+        >
+          Import successful
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/app/properties/page.tsx
+++ b/apps/web/app/properties/page.tsx
@@ -11,6 +11,15 @@ export default async function PropertiesPage() {
   return (
     <div>
       <h1>Properties</h1>
+      <div>
+        <a href="/properties/import">Import CSV</a>
+        <a
+          href={`${process.env.NEXT_PUBLIC_API_URL}/properties:export`}
+          style={{ marginLeft: '1rem' }}
+        >
+          Export CSV
+        </a>
+      </div>
       <ul>
         {properties.map((p: any) => (
           <li key={p.id}>


### PR DESCRIPTION
## Summary
- add POST `/properties:import` and GET `/properties:export` endpoints
- implement CSV parsing, validation, and creation of properties and units
- web UI for CSV import with drag-and-drop, error preview, and success toast

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: turbo: not found)


------
https://chatgpt.com/codex/tasks/task_e_68aba345b4a4832eb1ad597602d6958b