### PR TITLE
feat: add virtual tour support

### DIFF
--- a/apps/api/prisma/migrations/003_add_virtual_tour/migration.sql
+++ b/apps/api/prisma/migrations/003_add_virtual_tour/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "Unit" ADD COLUMN "virtualTourEmbedUrl" TEXT,
+                      ADD COLUMN "virtualTourImages" TEXT[] DEFAULT ARRAY[]::TEXT[];

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -132,6 +132,8 @@ model Unit {
   visits          Visit[]
   createdAt       DateTime         @default(now())
   imageUrl        String?
+  virtualTourEmbedUrl String?
+  virtualTourImages  String[]      @default([])
   deletedAt       DateTime?
 }
 

--- a/apps/api/src/unit/unit.controller.ts
+++ b/apps/api/src/unit/unit.controller.ts
@@ -15,6 +15,7 @@ import { UnitService } from './unit.service';
 const UnitCreate = z.object({
   name: z.string(),
   propertyId: z.string(),
+  virtualTourEmbedUrl: z.string().url().optional(),
 });
 
 const UnitUpdate = UnitCreate.partial();
@@ -60,6 +61,12 @@ export class UnitController {
   uploadPhoto(@Param('id') id: string, @Body() body: any) {
     const { filename, contentType } = UploadPhoto.parse(body);
     return this.service.createPhotoUpload(id, filename, contentType);
+  }
+
+  @Post(':id/virtual-tour/photo')
+  uploadVirtualTourPhoto(@Param('id') id: string, @Body() body: any) {
+    const { filename, contentType } = UploadPhoto.parse(body);
+    return this.service.createVirtualTourImageUpload(id, filename, contentType);
   }
 }
 

--- a/apps/api/src/unit/unit.service.ts
+++ b/apps/api/src/unit/unit.service.ts
@@ -17,7 +17,11 @@ export class UnitService {
     return this.repo.findUnique(id);
   }
 
-  create(data: { name: string; propertyId: string }) {
+  create(data: {
+    name: string;
+    propertyId: string;
+    virtualTourEmbedUrl?: string;
+  }) {
     return this.repo.create(data);
   }
 
@@ -33,6 +37,19 @@ export class UnitService {
     const key = `units/${id}/${Date.now()}-${filename}`;
     const signed = await this.s3.getSignedUploadUrl(key, contentType);
     await this.repo.update(id, { imageUrl: signed.url });
+    return signed;
+  }
+
+  async createVirtualTourImageUpload(
+    id: string,
+    filename: string,
+    contentType: string,
+  ) {
+    const key = `units/${id}/virtual-tours/${Date.now()}-${filename}`;
+    const signed = await this.s3.getSignedUploadUrl(key, contentType);
+    await this.repo.update(id, {
+      virtualTourImages: { push: signed.url },
+    });
     return signed;
   }
 }

--- a/apps/web/app/units/[id]/UnitDetailClient.tsx
+++ b/apps/web/app/units/[id]/UnitDetailClient.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { useState } from 'react';
+import { ImageUploader } from '@/components/ImageUploader';
+
+interface Props {
+  unit: any;
+}
+
+export default function UnitDetailClient({ unit }: Props) {
+  const [tab, setTab] = useState<'details' | 'virtual'>('details');
+  const [embedUrl, setEmbedUrl] = useState(unit.virtualTourEmbedUrl || '');
+  const [saving, setSaving] = useState(false);
+  const [images, setImages] = useState<string[]>(unit.virtualTourImages || []);
+
+  async function saveEmbed() {
+    setSaving(true);
+    await fetch(`${process.env.NEXT_PUBLIC_API_URL}/units/${unit.id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ virtualTourEmbedUrl: embedUrl }),
+    });
+    setSaving(false);
+  }
+
+  return (
+    <div>
+      <h1>{unit.name}</h1>
+      <div className="flex gap-2">
+        <button onClick={() => setTab('details')}>Details</button>
+        <button onClick={() => setTab('virtual')}>Virtual Tour</button>
+      </div>
+      {tab === 'details' && (
+        <div>
+          {unit.imageUrl && (
+            <img src={unit.imageUrl} alt={unit.name} className="max-w-sm" />
+          )}
+          <ImageUploader
+            uploadUrlEndpoint={`${process.env.NEXT_PUBLIC_API_URL}/units/${unit.id}/photo`}
+          />
+        </div>
+      )}
+      {tab === 'virtual' && (
+        <div className="mt-4 space-y-4">
+          <div className="flex items-center gap-2">
+            <input
+              value={embedUrl}
+              onChange={(e) => setEmbedUrl(e.target.value)}
+              placeholder="Embed URL (e.g. Matterport)"
+              className="border p-1 flex-1"
+            />
+            <button onClick={saveEmbed} disabled={saving} className="border px-2">
+              Save
+            </button>
+          </div>
+          {embedUrl && (
+            <iframe src={embedUrl} className="w-full h-96" />
+          )}
+          <ImageUploader
+            uploadUrlEndpoint={`${process.env.NEXT_PUBLIC_API_URL}/units/${unit.id}/virtual-tour/photo`}
+            onUploaded={(url) => setImages([...images, url])}
+          />
+          <div className="flex flex-wrap gap-2">
+            {images.map((url) => (
+              <img key={url} src={url} alt="virtual tour" className="h-48" />
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/app/units/[id]/page.tsx
+++ b/apps/web/app/units/[id]/page.tsx
@@ -1,4 +1,4 @@
-import { ImageUploader } from '@/components/ImageUploader';
+import UnitDetailClient from './UnitDetailClient';
 
 async function fetchUnit(id: string) {
   const res = await fetch(
@@ -14,16 +14,5 @@ interface Props {
 
 export default async function UnitDetail({ params }: Props) {
   const unit = await fetchUnit(params.id);
-  return (
-    <div>
-      <h1>{unit.name}</h1>
-      {unit.imageUrl && (
-        <img src={unit.imageUrl} alt={unit.name} className="max-w-sm" />
-      )}
-      <ImageUploader
-        uploadUrlEndpoint={`${process.env.NEXT_PUBLIC_API_URL}/units/${unit.id}/photo`}
-      />
-    </div>
-  );
+  return <UnitDetailClient unit={unit} />;
 }
-


### PR DESCRIPTION
## Summary
- allow units to store virtual tour embed URL and gallery images
- enable uploading 360° images to S3 and patch embed URL via new endpoints
- add Virtual Tour tab on unit detail with iframe embed and image gallery

## Testing
- `npm test` (fails: Missing script: "test")
- `npx -y turbo lint` (fails: Could not resolve workspaces; Missing `packageManager` field)


------
https://chatgpt.com/codex/tasks/task_e_68aba54dbf54832e9dd6c2ee4aa5ae0c