### PR TITLE
feat: add lease creation with extended terms

### DIFF
--- a/apps/api/prisma/migrations/004_add_lease_terms/migration.sql
+++ b/apps/api/prisma/migrations/004_add_lease_terms/migration.sql
@@ -1,0 +1,15 @@
+-- CreateEnum
+CREATE TYPE "RentFrequency" AS ENUM ('weekly', 'monthly', 'yearly');
+
+-- CreateEnum
+CREATE TYPE "LeaseStatus" AS ENUM ('draft', 'active', 'renewing', 'ended');
+
+-- AlterTable
+ALTER TABLE "Lease"
+  ADD COLUMN "rentAmount" DOUBLE PRECISION NOT NULL,
+  ADD COLUMN "rentFrequency" "RentFrequency" NOT NULL,
+  ADD COLUMN "depositAmount" DOUBLE PRECISION,
+  ADD COLUMN "utilityAllowances" JSONB,
+  ADD COLUMN "autoRenew" BOOLEAN NOT NULL DEFAULT false,
+  ADD COLUMN "breakClause" TEXT,
+  ADD COLUMN "status" "LeaseStatus" NOT NULL DEFAULT 'draft';

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -169,6 +169,19 @@ model Household {
   createdAt DateTime     @default(now())
 }
 
+enum RentFrequency {
+  weekly
+  monthly
+  yearly
+}
+
+enum LeaseStatus {
+  draft
+  active
+  renewing
+  ended
+}
+
 model Lease {
   id          String       @id @default(cuid())
   org         Organization @relation(fields: [orgId], references: [id])
@@ -179,6 +192,13 @@ model Lease {
   householdId String
   startDate   DateTime
   endDate     DateTime?
+  rentAmount  Float
+  rentFrequency RentFrequency
+  depositAmount Float?
+  utilityAllowances Json?
+  autoRenew   Boolean      @default(false)
+  breakClause String?
+  status      LeaseStatus  @default(draft)
   invoices    Invoice[]
   deposits    Deposit[]
   documents   Document[]   @relation("LeaseDocuments")

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -16,6 +16,9 @@ import { DeviceController } from './device/device.controller';
 import { DeviceRepository } from './device/device.repository';
 import { DeviceService } from './device/device.service';
 import { SmartDeviceProvider } from './device/smart-device.provider';
+import { LeaseController } from './lease/lease.controller';
+import { LeaseRepository } from './lease/lease.repository';
+import { LeaseService } from './lease/lease.service';
 
 @Module({
   imports: [AuthModule],
@@ -25,6 +28,7 @@ import { SmartDeviceProvider } from './device/smart-device.provider';
     UnitController,
     PropertyImportExportController,
     DeviceController,
+    LeaseController,
   ],
   providers: [
     AppService,
@@ -37,6 +41,8 @@ import { SmartDeviceProvider } from './device/smart-device.provider';
     DeviceRepository,
     DeviceService,
     SmartDeviceProvider,
+    LeaseRepository,
+    LeaseService,
     TenantGuard,
   ],
 })

--- a/apps/api/src/lease/lease.controller.ts
+++ b/apps/api/src/lease/lease.controller.ts
@@ -1,0 +1,35 @@
+import { Body, Controller, Post } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import { z } from 'zod';
+import { LeaseService } from './lease.service';
+
+const LeaseCreate = z.object({
+  unitId: z.string(),
+  householdId: z.string(),
+  startDate: z.string().datetime(),
+  endDate: z.string().datetime().optional(),
+  rentAmount: z.number(),
+  rentFrequency: z.enum(['weekly', 'monthly', 'yearly']),
+  depositAmount: z.number().optional(),
+  utilityAllowances: z.any().optional(),
+  autoRenew: z.boolean().optional(),
+  breakClause: z.string().optional(),
+  status: z.enum(['draft', 'active', 'renewing', 'ended']).optional(),
+});
+
+@ApiTags('leases')
+@Controller('leases')
+export class LeaseController {
+  constructor(private readonly service: LeaseService) {}
+
+  @Post()
+  create(@Body() body: any) {
+    const data = LeaseCreate.parse(body);
+    return this.service.create({
+      ...data,
+      startDate: new Date(data.startDate),
+      endDate: data.endDate ? new Date(data.endDate) : undefined,
+    });
+  }
+}
+

--- a/apps/api/src/lease/lease.repository.ts
+++ b/apps/api/src/lease/lease.repository.ts
@@ -1,0 +1,17 @@
+import { Inject, Injectable, Scope } from '@nestjs/common';
+import { REQUEST } from '@nestjs/core';
+import { Request } from 'express';
+import { PrismaService } from '../prisma.service';
+import { BaseRepository } from '../common/base.repository';
+
+@Injectable({ scope: Scope.REQUEST })
+export class LeaseRepository extends BaseRepository<any> {
+  constructor(
+    prisma: PrismaService,
+    @Inject(REQUEST) request: Request,
+  ) {
+    super(prisma, request);
+    this.model = prisma.lease;
+  }
+}
+

--- a/apps/api/src/lease/lease.service.ts
+++ b/apps/api/src/lease/lease.service.ts
@@ -1,0 +1,28 @@
+import { Injectable, Scope } from '@nestjs/common';
+import { LeaseRepository } from './lease.repository';
+
+@Injectable({ scope: Scope.REQUEST })
+export class LeaseService {
+  constructor(private readonly repo: LeaseRepository) {}
+
+  create(data: {
+    unitId: string;
+    householdId: string;
+    startDate: Date;
+    endDate?: Date;
+    rentAmount: number;
+    rentFrequency: string;
+    depositAmount?: number;
+    utilityAllowances?: any;
+    autoRenew?: boolean;
+    breakClause?: string;
+    status?: string;
+  }) {
+    return this.repo.create({
+      ...data,
+      autoRenew: data.autoRenew ?? false,
+      status: data.status ?? 'draft',
+    });
+  }
+}
+


### PR DESCRIPTION
## Summary
- add rent, deposit, utilities and status fields to leases
- support creating leases with terms and household assignment

## Testing
- `npm run lint` *(fails: turbo not found)*
- `npm test` *(fails: Missing script "test")*
- `npx prisma generate` *(fails: Device relation missing on Organization)*

------
https://chatgpt.com/codex/tasks/task_e_68abba3b3ebc832ea6446f80ff964074