### PR TITLE
feat: add rent pricing suggestions

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -26,6 +26,8 @@ import { CertificateController } from './certificate/certificate.controller';
 import { CertificateService } from './certificate/certificate.service';
 import { CertificateRepository } from './certificate/certificate.repository';
 import { CertificateReminderService } from './certificate/certificate.scheduler';
+import { PricingController } from './pricing/pricing.controller';
+import { PricingService } from './pricing/pricing.service';
 
 @Module({
   imports: [AuthModule, ScheduleModule.forRoot()],
@@ -36,6 +38,7 @@ import { CertificateReminderService } from './certificate/certificate.scheduler'
     PropertyImportExportController,
     DeviceController,
     LeaseController,
+    PricingController,
     CertificateController,
   ],
   providers: [
@@ -54,6 +57,7 @@ import { CertificateReminderService } from './certificate/certificate.scheduler'
     PdfService,
     EsignService,
     TenantGuard,
+    PricingService,
     CertificateRepository,
     CertificateService,
     CertificateReminderService,

--- a/apps/api/src/lease/lease.controller.ts
+++ b/apps/api/src/lease/lease.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Param, Post } from '@nestjs/common';
+import { Body, Controller, Get, Param, Post, Patch } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { z } from 'zod';
 import { LeaseService } from './lease.service';
@@ -17,6 +17,8 @@ const LeaseCreate = z.object({
   status: z.enum(['draft', 'active', 'renewing', 'ended']).optional(),
 });
 
+const LeaseUpdate = LeaseCreate.partial();
+
 @ApiTags('leases')
 @Controller('leases')
 export class LeaseController {
@@ -30,6 +32,12 @@ export class LeaseController {
       startDate: new Date(data.startDate),
       endDate: data.endDate ? new Date(data.endDate) : undefined,
     });
+  }
+
+  @Patch(':id')
+  update(@Param('id') id: string, @Body() body: any) {
+    const data = LeaseUpdate.parse(body);
+    return this.service.update(id, data);
   }
 
   /** Generate and return a lease PDF URL. */

--- a/apps/api/src/lease/lease.service.ts
+++ b/apps/api/src/lease/lease.service.ts
@@ -31,6 +31,10 @@ export class LeaseService {
     });
   }
 
+  update(id: string, data: any) {
+    return this.repo.update(id, data);
+  }
+
   /** Generate a lease PDF and upload to S3. */
   async generatePdf(id: string) {
     const lease = await this.repo.findUnique(id, {

--- a/apps/api/src/pricing/pricing.controller.ts
+++ b/apps/api/src/pricing/pricing.controller.ts
@@ -1,0 +1,18 @@
+import { Controller, Get, Query } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import { z } from 'zod';
+import { PricingService } from './pricing.service';
+
+const SuggestQuery = z.object({ unitId: z.string() });
+
+@ApiTags('pricing')
+@Controller('pricing')
+export class PricingController {
+  constructor(private readonly service: PricingService) {}
+
+  @Get('suggestions')
+  suggestions(@Query() query: any) {
+    const { unitId } = SuggestQuery.parse(query);
+    return this.service.suggest(unitId);
+  }
+}

--- a/apps/api/src/pricing/pricing.service.ts
+++ b/apps/api/src/pricing/pricing.service.ts
@@ -1,0 +1,30 @@
+import { Injectable, Scope } from '@nestjs/common';
+import { LeaseRepository } from '../lease/lease.repository';
+
+@Injectable({ scope: Scope.REQUEST })
+export class PricingService {
+  constructor(private readonly leases: LeaseRepository) {}
+
+  /**
+   * Compute suggested rent for a unit using simple factors.
+   * Currently uses local yield, occupancy and seasonality constants.
+   */
+  async suggest(unitId: string) {
+    const [lease] = await this.leases.findMany({
+      where: { unitId },
+      orderBy: { startDate: 'desc' },
+      take: 1,
+    });
+    const currentRent = lease?.rentAmount ?? 0;
+    const suggestedRent = this.computeSuggested(currentRent);
+    return { leaseId: lease?.id, currentRent, suggestedRent };
+  }
+
+  /** Basic formula for suggested rent. */
+  private computeSuggested(current: number) {
+    const LOCAL_YIELD = 1.05; // 5% increase
+    const OCCUPANCY = 0.95; // 95% occupancy factor
+    const SEASONALITY = 1.1; // 10% seasonal uplift
+    return Math.round(current * LOCAL_YIELD * OCCUPANCY * SEASONALITY);
+  }
+}


### PR DESCRIPTION
## Summary
- add pricing service and endpoint for rent suggestions
- support updating lease rent amounts
- show rent suggestions on unit detail UI with apply option

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: turbo: not found)
- `npx eslint apps/api/src/pricing/pricing.controller.ts apps/api/src/pricing/pricing.service.ts apps/api/src/lease/lease.controller.ts apps/api/src/lease/lease.service.ts apps/web/app/units/[id]/UnitDetailClient.tsx` (fails: ESLint couldn't find config)


------
https://chatgpt.com/codex/tasks/task_e_68abd4e82208832ebe809b6af22de844