### PR TITLE
feat: add lease amendment workflow

### DIFF
--- a/apps/api/prisma/migrations/005_add_lease_amendments/migration.sql
+++ b/apps/api/prisma/migrations/005_add_lease_amendments/migration.sql
@@ -1,0 +1,25 @@
+-- CreateEnum
+CREATE TYPE "AmendmentStatus" AS ENUM ('proposed', 'countered', 'accepted', 'rejected', 'signed');
+
+-- CreateTable
+CREATE TABLE "LeaseAmendment" (
+    "id" TEXT NOT NULL,
+    "orgId" TEXT NOT NULL,
+    "leaseId" TEXT NOT NULL,
+    "version" INTEGER NOT NULL,
+    "status" "AmendmentStatus" NOT NULL DEFAULT 'proposed',
+    "content" JSONB,
+    "pdfUrl" TEXT,
+    "redlineUrl" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "LeaseAmendment_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "LeaseAmendment_leaseId_version_key" ON "LeaseAmendment"("leaseId", "version");
+
+-- AddForeignKey
+ALTER TABLE "LeaseAmendment" ADD CONSTRAINT "LeaseAmendment_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Organization"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "LeaseAmendment" ADD CONSTRAINT "LeaseAmendment_leaseId_fkey" FOREIGN KEY ("leaseId") REFERENCES "Lease"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -204,6 +204,14 @@ enum LeaseStatus {
   ended
 }
 
+enum AmendmentStatus {
+  proposed
+  countered
+  accepted
+  rejected
+  signed
+}
+
 model Lease {
   id          String       @id @default(cuid())
   org         Organization @relation(fields: [orgId], references: [id])
@@ -224,7 +232,24 @@ model Lease {
   invoices    Invoice[]
   deposits    Deposit[]
   documents   Document[]   @relation("LeaseDocuments")
+  amendments  LeaseAmendment[]
   createdAt   DateTime     @default(now())
+}
+
+model LeaseAmendment {
+  id         String          @id @default(cuid())
+  org        Organization    @relation(fields: [orgId], references: [id])
+  orgId      String
+  lease      Lease           @relation(fields: [leaseId], references: [id])
+  leaseId    String
+  version    Int
+  status     AmendmentStatus @default(proposed)
+  content    Json?
+  pdfUrl     String?
+  redlineUrl String?
+  createdAt  DateTime        @default(now())
+
+  @@unique([leaseId, version])
 }
 
 model Invoice {

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -22,6 +22,9 @@ import { LeaseRepository } from './lease/lease.repository';
 import { LeaseService } from './lease/lease.service';
 import { PdfService } from './lease/pdf.service';
 import { EsignService } from './lease/esign.service';
+import { AmendmentController } from './lease/amendment.controller';
+import { AmendmentRepository } from './lease/amendment.repository';
+import { AmendmentService } from './lease/amendment.service';
 import { CertificateController } from './certificate/certificate.controller';
 import { CertificateService } from './certificate/certificate.service';
 import { CertificateRepository } from './certificate/certificate.repository';
@@ -38,6 +41,7 @@ import { PricingService } from './pricing/pricing.service';
     PropertyImportExportController,
     DeviceController,
     LeaseController,
+    AmendmentController,
     PricingController,
     CertificateController,
   ],
@@ -54,6 +58,8 @@ import { PricingService } from './pricing/pricing.service';
     SmartDeviceProvider,
     LeaseRepository,
     LeaseService,
+    AmendmentRepository,
+    AmendmentService,
     PdfService,
     EsignService,
     TenantGuard,

--- a/apps/api/src/lease/amendment.controller.ts
+++ b/apps/api/src/lease/amendment.controller.ts
@@ -1,0 +1,43 @@
+import { Body, Controller, Get, Param, Post } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import { z } from 'zod';
+import { AmendmentService } from './amendment.service';
+
+const AmendmentCreate = z.object({ content: z.any().optional() });
+
+@ApiTags('lease-amendments')
+@Controller('leases/:leaseId/amendments')
+export class AmendmentController {
+  constructor(private readonly service: AmendmentService) {}
+
+  @Get()
+  list(@Param('leaseId') leaseId: string) {
+    return this.service.list(leaseId);
+  }
+
+  @Post()
+  create(@Param('leaseId') leaseId: string, @Body() body: any) {
+    const data = AmendmentCreate.parse(body);
+    return this.service.propose(leaseId, data.content);
+  }
+
+  @Post(':id/counter')
+  counter(
+    @Param('leaseId') leaseId: string,
+    @Param('id') id: string,
+    @Body() body: any,
+  ) {
+    const data = AmendmentCreate.parse(body);
+    return this.service.counter(id, data.content);
+  }
+
+  @Post(':id/accept')
+  accept(@Param('id') id: string) {
+    return this.service.accept(id);
+  }
+
+  @Post(':id/esign/start')
+  startEsign(@Param('id') id: string) {
+    return this.service.startEsign(id);
+  }
+}

--- a/apps/api/src/lease/amendment.repository.ts
+++ b/apps/api/src/lease/amendment.repository.ts
@@ -1,0 +1,16 @@
+import { Inject, Injectable, Scope } from '@nestjs/common';
+import { REQUEST } from '@nestjs/core';
+import { Request } from 'express';
+import { PrismaService } from '../prisma.service';
+import { BaseRepository } from '../common/base.repository';
+
+@Injectable({ scope: Scope.REQUEST })
+export class AmendmentRepository extends BaseRepository<any> {
+  constructor(
+    prisma: PrismaService,
+    @Inject(REQUEST) request: Request,
+  ) {
+    super(prisma, request);
+    this.model = prisma.leaseAmendment;
+  }
+}

--- a/apps/api/src/lease/amendment.service.ts
+++ b/apps/api/src/lease/amendment.service.ts
@@ -1,0 +1,52 @@
+import { Injectable, Scope } from '@nestjs/common';
+import { AmendmentRepository } from './amendment.repository';
+import { PdfService } from './pdf.service';
+import { EsignService } from './esign.service';
+
+@Injectable({ scope: Scope.REQUEST })
+export class AmendmentService {
+  constructor(
+    private readonly repo: AmendmentRepository,
+    private readonly pdf: PdfService,
+    private readonly esign: EsignService,
+  ) {}
+
+  list(leaseId: string) {
+    return this.repo.findMany({ where: { leaseId }, orderBy: { version: 'asc' } });
+  }
+
+  async propose(leaseId: string, content: any) {
+    const [last] = await this.repo.findMany({
+      where: { leaseId },
+      orderBy: { version: 'desc' },
+      take: 1,
+    });
+    const version = last ? last.version + 1 : 1;
+    return this.repo.create({ leaseId, version, content });
+  }
+
+  async counter(id: string, content: any) {
+    const existing = await this.repo.findUnique(id);
+    if (!existing) throw new Error('Amendment not found');
+    await this.repo.update(id, { status: 'countered' });
+    const [last] = await this.repo.findMany({
+      where: { leaseId: existing.leaseId },
+      orderBy: { version: 'desc' },
+      take: 1,
+    });
+    const version = last ? last.version + 1 : 1;
+    return this.repo.create({ leaseId: existing.leaseId, version, content });
+  }
+
+  accept(id: string) {
+    return this.repo.update(id, { status: 'accepted' });
+  }
+
+  async startEsign(id: string) {
+    const amendment = await this.repo.findUnique(id);
+    if (!amendment) throw new Error('Amendment not found');
+    const pdf = await this.pdf.generateAmendmentPdf(amendment);
+    await this.repo.update(id, { pdfUrl: pdf.url, redlineUrl: pdf.redlineUrl });
+    return this.esign.start(amendment, pdf.url);
+  }
+}

--- a/apps/api/src/lease/pdf.service.ts
+++ b/apps/api/src/lease/pdf.service.ts
@@ -31,4 +31,45 @@ export class PdfService {
     const { url } = await this.s3.upload(key, buffer, 'application/pdf');
     return { url };
   }
+
+  /** Generate an amendment PDF and a placeholder redline. */
+  async generateAmendmentPdf(amendment: any) {
+    const template = Handlebars.compile(
+      `Lease Amendment v${'{{version}}'}\n\n{{json content}}`
+    );
+    const content = template({
+      version: amendment.version,
+      content: amendment.content,
+    });
+
+    const doc = new PDFDocument();
+    const chunks: Buffer[] = [];
+    doc.on('data', (d) => chunks.push(d));
+    doc.text(content);
+    doc.end();
+    const buffer: Buffer = await new Promise((resolve) => {
+      doc.on('end', () => resolve(Buffer.concat(chunks)));
+    });
+
+    const key = `leases/${amendment.leaseId}-amendment-${amendment.version}.pdf`;
+    const { url } = await this.s3.upload(key, buffer, 'application/pdf');
+
+    // Generate a trivial redline PDF as a placeholder
+    const redlineDoc = new PDFDocument();
+    const redlineChunks: Buffer[] = [];
+    redlineDoc.on('data', (d) => redlineChunks.push(d));
+    redlineDoc.text('Redline preview');
+    redlineDoc.end();
+    const redlineBuffer: Buffer = await new Promise((resolve) => {
+      redlineDoc.on('end', () => resolve(Buffer.concat(redlineChunks)));
+    });
+    const redlineKey = `leases/${amendment.leaseId}-amendment-${amendment.version}-redline.pdf`;
+    const { url: redlineUrl } = await this.s3.upload(
+      redlineKey,
+      redlineBuffer,
+      'application/pdf',
+    );
+
+    return { url, redlineUrl };
+  }
 }

--- a/apps/web/app/leases/[id]/amendments/page.tsx
+++ b/apps/web/app/leases/[id]/amendments/page.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useParams } from 'next/navigation';
+import { StatusChip } from '../../../../components/StatusChip';
+
+export default function LeaseAmendmentsPage() {
+  const params = useParams();
+  const leaseId = (params as any).id as string;
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001';
+  const [amendments, setAmendments] = useState<any[]>([]);
+
+  useEffect(() => {
+    fetch(`${apiUrl}/leases/${leaseId}/amendments`)
+      .then((res) => res.json())
+      .then(setAmendments)
+      .catch(() => setAmendments([]));
+  }, [apiUrl, leaseId]);
+
+  return (
+    <div className="space-y-4">
+      <h1>Amendments</h1>
+      <ul className="space-y-2">
+        {amendments.map((a) => (
+          <li key={a.id} className="flex items-center space-x-2">
+            <span>v{a.version}</span>
+            <StatusChip text={a.status} color="blue" />
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/apps/web/app/leases/[id]/page.tsx
+++ b/apps/web/app/leases/[id]/page.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { useParams } from 'next/navigation';
 import { Button } from '@tenancy/ui';
 import { StatusChip } from '../../../components/StatusChip';
+import Link from 'next/link';
 
 export default function LeasePage() {
   const params = useParams();
@@ -30,6 +31,9 @@ export default function LeasePage() {
       <div className="space-x-2">
         <Button onClick={generatePdf}>Generate PDF</Button>
         <Button onClick={sendForSignature}>Send for signature</Button>
+        <Link href={`/leases/${id}/amendments`} className="underline">
+          View amendments
+        </Link>
       </div>
       <div className="flex space-x-2">
         {pdfUrl && <StatusChip text="PDF generated" color="green" />}


### PR DESCRIPTION
## Summary
- add `LeaseAmendment` model and schema for versioned lease amendments
- expose amendment proposal, counter, accept and e-sign endpoints
- basic UI page to view lease amendment thread

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: turbo: not found)*
- `npm run typecheck` *(fails: turbo: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68afc881d2c4832e9de31122c766e750