### PR TITLE
feat: add notice pdf generation

### DIFF
--- a/apps/api/prisma/migrations/20240601120000_add_notice/migration.sql
+++ b/apps/api/prisma/migrations/20240601120000_add_notice/migration.sql
@@ -1,0 +1,15 @@
+-- CreateTable
+CREATE TABLE "Notice" (
+    "id" TEXT NOT NULL,
+    "orgId" TEXT NOT NULL,
+    "leaseId" TEXT NOT NULL,
+    "type" TEXT NOT NULL,
+    "pdfUrl" TEXT NOT NULL,
+    "acknowledgedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "Notice_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "Notice" ADD CONSTRAINT "Notice_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Organization"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "Notice" ADD CONSTRAINT "Notice_leaseId_fkey" FOREIGN KEY ("leaseId") REFERENCES "Lease"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -339,6 +339,18 @@ model Document {
   createdAt DateTime     @default(now())
 }
 
+model Notice {
+  id            String       @id @default(cuid())
+  org           Organization @relation(fields: [orgId], references: [id])
+  orgId         String
+  lease         Lease        @relation(fields: [leaseId], references: [id])
+  leaseId       String
+  type          String
+  pdfUrl        String
+  acknowledgedAt DateTime?
+  createdAt     DateTime     @default(now())
+}
+
 model Notification {
   id        String       @id @default(cuid())
   org       Organization @relation(fields: [orgId], references: [id])

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -31,6 +31,10 @@ import { CertificateRepository } from './certificate/certificate.repository';
 import { CertificateReminderService } from './certificate/certificate.scheduler';
 import { PricingController } from './pricing/pricing.controller';
 import { PricingService } from './pricing/pricing.service';
+import { NoticeController } from './notice/notice.controller';
+import { NoticeRepository } from './notice/notice.repository';
+import { NoticeService } from './notice/notice.service';
+import { NoticePdfService } from './notice/pdf.service';
 
 @Module({
   imports: [AuthModule, ScheduleModule.forRoot()],
@@ -44,6 +48,7 @@ import { PricingService } from './pricing/pricing.service';
     AmendmentController,
     PricingController,
     CertificateController,
+    NoticeController,
   ],
   providers: [
     AppService,
@@ -67,6 +72,9 @@ import { PricingService } from './pricing/pricing.service';
     CertificateRepository,
     CertificateService,
     CertificateReminderService,
+    NoticeRepository,
+    NoticeService,
+    NoticePdfService,
   ],
 })
 export class AppModule {}

--- a/apps/api/src/notice/notice.controller.ts
+++ b/apps/api/src/notice/notice.controller.ts
@@ -1,0 +1,17 @@
+import { Body, Controller, Param, Post } from '@nestjs/common';
+import { NoticeService } from './notice.service';
+
+@Controller('notice')
+export class NoticeController {
+  constructor(private readonly service: NoticeService) {}
+
+  @Post()
+  create(@Body() body: any) {
+    return this.service.create(body);
+  }
+
+  @Post(':id/acknowledge')
+  acknowledge(@Param('id') id: string) {
+    return this.service.acknowledge(id);
+  }
+}

--- a/apps/api/src/notice/notice.repository.ts
+++ b/apps/api/src/notice/notice.repository.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma.service';
+import { Prisma } from '@prisma/client';
+
+@Injectable()
+export class NoticeRepository {
+  constructor(private prisma: PrismaService) {}
+
+  create(data: Prisma.NoticeCreateInput) {
+    return this.prisma.notice.create({ data });
+  }
+
+  update(id: string, data: Prisma.NoticeUpdateInput) {
+    return this.prisma.notice.update({ where: { id }, data });
+  }
+
+  findById(id: string) {
+    return this.prisma.notice.findUnique({ where: { id } });
+  }
+}

--- a/apps/api/src/notice/notice.service.ts
+++ b/apps/api/src/notice/notice.service.ts
@@ -1,0 +1,35 @@
+import { Injectable } from '@nestjs/common';
+import { randomUUID } from 'crypto';
+import { NoticeRepository } from './notice.repository';
+import { NoticePdfService } from './pdf.service';
+
+@Injectable()
+export class NoticeService {
+  constructor(
+    private readonly repo: NoticeRepository,
+    private readonly pdf: NoticePdfService,
+  ) {}
+
+  async create(data: {
+    orgId: string;
+    leaseId: string;
+    type: 'section21' | 'hud';
+    tenantName: string;
+    issueDate: string;
+    deadline: string;
+  }) {
+    const id = randomUUID();
+    const { url } = await this.pdf.generate(id, data.type, data);
+    return this.repo.create({
+      id,
+      orgId: data.orgId,
+      leaseId: data.leaseId,
+      type: data.type,
+      pdfUrl: url,
+    });
+  }
+
+  acknowledge(id: string) {
+    return this.repo.update(id, { acknowledgedAt: new Date() });
+  }
+}

--- a/apps/api/src/notice/pdf.service.ts
+++ b/apps/api/src/notice/pdf.service.ts
@@ -1,0 +1,34 @@
+import { Injectable } from '@nestjs/common';
+import Handlebars from 'handlebars';
+import PDFDocument from 'pdfkit';
+import { S3Service } from '../s3.service';
+
+@Injectable()
+export class NoticePdfService {
+  constructor(private readonly s3: S3Service) {}
+
+  private templates: Record<string, string> = {
+    section21:
+      'Section 21 Notice\n\nTenant: {{tenantName}}\nIssued: {{issueDate}}\nVacate By: {{deadline}}',
+    hud:
+      'HUD Notice\n\nTenant: {{tenantName}}\nIssued: {{issueDate}}\nCompliance Date: {{deadline}}',
+  };
+
+  async generate(id: string, type: 'section21' | 'hud', data: any) {
+    const template = Handlebars.compile(this.templates[type]);
+    const content = template(data);
+
+    const doc = new PDFDocument();
+    const chunks: Buffer[] = [];
+    doc.on('data', (d) => chunks.push(d));
+    doc.text(content);
+    doc.end();
+    const buffer: Buffer = await new Promise((resolve) => {
+      doc.on('end', () => resolve(Buffer.concat(chunks)));
+    });
+
+    const key = `notices/${id}.pdf`;
+    const { url } = await this.s3.upload(key, buffer, 'application/pdf');
+    return { url };
+  }
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -2,3 +2,14 @@ export interface User {
   id: string;
   email: string;
 }
+
+export type NoticeType = 'section21' | 'hud';
+
+export interface Notice {
+  id: string;
+  leaseId: string;
+  type: NoticeType;
+  pdfUrl: string;
+  acknowledgedAt?: Date;
+  createdAt: Date;
+}


### PR DESCRIPTION
## Summary
- add notice API for templated UK Section 21 and US HUD notices
- render notice PDFs and store S3 URL on records
- track tenant acknowledgements

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: turbo not found)
- `npm run typecheck` (fails: turbo not found)


------
https://chatgpt.com/codex/tasks/task_e_68afc9af9028832eab8fea90523301d2