### PR TITLE
feat: generate invoices with proration and tax

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,8 @@
     "build": "tsc -p tsconfig.build.json",
     "start": "node dist/main.js",
     "lint": "eslint 'src/**/*.{ts,tsx}'",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "tsc src/invoice/invoice.utils.ts src/invoice/invoice.service.spec.ts --module commonjs --target es2019 --outDir dist-test --esModuleInterop --skipLibCheck && node dist-test/invoice.service.spec.js"
   },
   "dependencies": {
     "@nestjs/common": "^10.2.5",

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -258,10 +258,22 @@ model Invoice {
   orgId     String
   lease     Lease        @relation(fields: [leaseId], references: [id])
   leaseId   String
+  subtotal  Float
+  tax       Float
   amount    Float
   dueDate   DateTime
   payments  Payment[]
+  lineItems InvoiceLineItem[]
   createdAt DateTime     @default(now())
+}
+
+model InvoiceLineItem {
+  id          String   @id @default(cuid())
+  invoice     Invoice  @relation(fields: [invoiceId], references: [id])
+  invoiceId   String
+  description String
+  amount      Float
+  taxRate     Float?
 }
 
 model Payment {

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -35,6 +35,7 @@ import { NoticeController } from './notice/notice.controller';
 import { NoticeRepository } from './notice/notice.repository';
 import { NoticeService } from './notice/notice.service';
 import { NoticePdfService } from './notice/pdf.service';
+import { InvoiceService } from './invoice/invoice.service';
 
 @Module({
   imports: [AuthModule, ScheduleModule.forRoot()],
@@ -75,6 +76,7 @@ import { NoticePdfService } from './notice/pdf.service';
     NoticeRepository,
     NoticeService,
     NoticePdfService,
+    InvoiceService,
   ],
 })
 export class AppModule {}

--- a/apps/api/src/invoice/invoice.service.spec.ts
+++ b/apps/api/src/invoice/invoice.service.spec.ts
@@ -1,0 +1,54 @@
+// @ts-nocheck
+import assert from 'assert';
+import {
+  Lease,
+  generateInvoiceForDate,
+  calculateTotals,
+} from './invoice.utils';
+
+async function runTests() {
+  // Monthly proration tests
+  {
+    const lease: Lease = {
+      id: 'l1',
+      startDate: new Date('2024-04-10'),
+      endDate: new Date('2024-06-20'),
+      rentAmount: 1000,
+      rentFrequency: 'monthly',
+    };
+    const invoice1 = generateInvoiceForDate(lease, new Date('2024-04-15'))!;
+    assert.ok(Math.abs(invoice1.total - 700) < 0.01);
+    const invoice2 = generateInvoiceForDate(lease, new Date('2024-06-10'))!;
+    assert.ok(Math.abs(invoice2.total - (1000 * 20) / 30) < 0.01);
+  }
+
+  // Weekly proration tests
+  {
+    const lease: Lease = {
+      id: 'l2',
+      startDate: new Date('2024-01-01'),
+      endDate: new Date('2024-01-10'),
+      rentAmount: 700,
+      rentFrequency: 'weekly',
+    };
+    const invoice1 = generateInvoiceForDate(lease, new Date('2024-01-03'))!;
+    assert.ok(Math.abs(invoice1.total - 700) < 0.01);
+    const invoice2 = generateInvoiceForDate(lease, new Date('2024-01-08'))!;
+    assert.ok(Math.abs(invoice2.total - 300) < 0.01);
+  }
+
+  // Line item + tax test
+  {
+    const totals = calculateTotals([
+      { description: 'Rent', amount: 1000, taxRate: 0.1 },
+      { description: 'Service', amount: 100 },
+    ]);
+    assert.strictEqual(totals.subtotal, 1100);
+    assert.ok(Math.abs(totals.tax - 100) < 0.01);
+    assert.ok(Math.abs(totals.total - 1200) < 0.01);
+  }
+
+  console.log('All tests passed');
+}
+
+runTests();

--- a/apps/api/src/invoice/invoice.service.ts
+++ b/apps/api/src/invoice/invoice.service.ts
@@ -1,0 +1,70 @@
+import { Injectable } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
+import { PrismaService } from '../prisma.service';
+import {
+  Lease,
+  InvoiceData,
+  generateInvoiceForDate,
+} from './invoice.utils';
+
+/**
+ * Service responsible for generating invoices from leases.
+ * Includes simple cron job that runs on the first of each month.
+ */
+@Injectable()
+export class InvoiceService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  /** Cron that runs monthly to generate invoices for active leases. */
+  @Cron('0 0 1 * *')
+  async handleCron() {
+    const leases: Lease[] = await this.prisma.lease.findMany({
+      where: { status: 'active' },
+    });
+    const today = new Date();
+    for (const lease of leases) {
+      await this.generateCurrentInvoice(lease, today);
+    }
+  }
+
+  /**
+   * Generate the invoice covering the period that contains `date`.
+   * For simplicity we do not check for existing invoices.
+   */
+  async generateCurrentInvoice(lease: Lease, date: Date): Promise<InvoiceData | null> {
+    if (lease.rentFrequency === 'monthly') {
+      const periodStart = new Date(date.getFullYear(), date.getMonth(), 1);
+      const periodEnd = new Date(date.getFullYear(), date.getMonth() + 1, 0);
+      if (periodEnd < lease.startDate) return null;
+      if (lease.endDate && periodStart > lease.endDate) return null;
+      const invoice = generateInvoiceForDate(lease, date);
+      await this.prisma.invoice.create({
+        data: {
+          leaseId: lease.id,
+          orgId: (await this.prisma.lease.findUnique({ where: { id: lease.id } })).orgId,
+          dueDate: invoice.periodStart,
+          subtotal: invoice.subtotal,
+          tax: invoice.tax,
+          amount: invoice.total,
+          lineItems: { create: invoice.lineItems },
+        },
+      });
+      return invoice;
+    } else {
+      const invoice = generateInvoiceForDate(lease, date);
+      await this.prisma.invoice.create({
+        data: {
+          leaseId: lease.id,
+          orgId: (await this.prisma.lease.findUnique({ where: { id: lease.id } })).orgId,
+          dueDate: invoice.periodStart,
+          subtotal: invoice.subtotal,
+          tax: invoice.tax,
+          amount: invoice.total,
+          lineItems: { create: invoice.lineItems },
+        },
+      });
+      return invoice;
+    }
+  }
+}
+

--- a/apps/api/src/invoice/invoice.utils.ts
+++ b/apps/api/src/invoice/invoice.utils.ts
@@ -1,0 +1,73 @@
+export interface Lease {
+  id: string;
+  startDate: Date;
+  endDate?: Date | null;
+  rentAmount: number;
+  rentFrequency: 'weekly' | 'monthly';
+}
+
+export interface InvoiceLineItem {
+  description: string;
+  amount: number;
+  taxRate?: number;
+}
+
+export interface InvoiceData {
+  leaseId: string;
+  periodStart: Date;
+  periodEnd: Date;
+  lineItems: InvoiceLineItem[];
+  subtotal: number;
+  tax: number;
+  total: number;
+}
+
+export function calculateTotals(lineItems: InvoiceLineItem[]) {
+  let subtotal = 0;
+  let tax = 0;
+  for (const item of lineItems) {
+    subtotal += item.amount;
+    if (item.taxRate) tax += item.amount * item.taxRate;
+  }
+  const total = subtotal + tax;
+  return { subtotal, tax, total };
+}
+
+export function prorateMonthly(amount: number, start: Date, end: Date): number {
+  const daysInPeriod = (end.getTime() - start.getTime()) / 86400000 + 1;
+  const daysInMonth = new Date(start.getFullYear(), start.getMonth() + 1, 0).getDate();
+  return (amount * daysInPeriod) / daysInMonth;
+}
+
+/** Generate invoice for the period containing `date` without persistence. */
+export function generateInvoiceForDate(
+  lease: Lease,
+  date: Date,
+  extraItems: InvoiceLineItem[] = [],
+): InvoiceData | null {
+  if (lease.rentFrequency === 'monthly') {
+    const periodStart = new Date(date.getFullYear(), date.getMonth(), 1);
+    const periodEnd = new Date(date.getFullYear(), date.getMonth() + 1, 0);
+    if (periodEnd < lease.startDate) return null;
+    if (lease.endDate && periodStart > lease.endDate) return null;
+    const start = lease.startDate > periodStart ? lease.startDate : periodStart;
+    const end = lease.endDate && lease.endDate < periodEnd ? lease.endDate : periodEnd;
+    const amount = prorateMonthly(lease.rentAmount, start, end);
+    const lineItems = [{ description: 'Rent', amount }, ...extraItems];
+    const totals = calculateTotals(lineItems);
+    return { leaseId: lease.id, periodStart: start, periodEnd: end, lineItems, ...totals };
+  } else {
+    const diff = Math.floor((date.getTime() - lease.startDate.getTime()) / 86400000);
+    if (diff < 0) return null;
+    const periodIndex = Math.floor(diff / 7);
+    const periodStart = new Date(lease.startDate.getTime() + periodIndex * 7 * 86400000);
+    let periodEnd = new Date(periodStart.getTime() + 6 * 86400000);
+    if (lease.endDate && periodStart > lease.endDate) return null;
+    if (lease.endDate && periodEnd > lease.endDate) periodEnd = lease.endDate;
+    const days = (periodEnd.getTime() - periodStart.getTime()) / 86400000 + 1;
+    const amount = lease.rentAmount * (days / 7);
+    const lineItems = [{ description: 'Rent', amount }, ...extraItems];
+    const totals = calculateTotals(lineItems);
+    return { leaseId: lease.id, periodStart, periodEnd, lineItems, ...totals };
+  }
+}


### PR DESCRIPTION
## Summary
- add invoice utilities for proration, frequency and tax calculation
- schedule cron to create invoices from active leases
- extend Prisma schema to support line items and tax totals
- unit tests for monthly/weekly edge cases

## Testing
- `npm run lint --workspace=apps/api` (fails: ESLint couldn't find config)
- `npm run typecheck --workspace=apps/api` (fails: tsc missing types)
- `npm test` in apps/api

------
https://chatgpt.com/codex/tasks/task_e_68afca7e94d8832e913617905fdb1021