### PR TITLE
feat: add invoice reminders and late fee policy UI

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -36,6 +36,7 @@ import { NoticeRepository } from './notice/notice.repository';
 import { NoticeService } from './notice/notice.service';
 import { NoticePdfService } from './notice/pdf.service';
 import { InvoiceService } from './invoice/invoice.service';
+import { InvoiceReminderService } from './invoice/invoice.scheduler';
 import { PaymentController } from './payment/payment.controller';
 import { PaymentService } from './payment/payment.service';
 import { StripeProvider } from './payment/providers/stripe.provider';
@@ -83,6 +84,7 @@ import { SquareProvider } from './payment/providers/square.provider';
     NoticeService,
     NoticePdfService,
     InvoiceService,
+    InvoiceReminderService,
     PaymentService,
     StripeProvider,
     PaypalProvider,

--- a/apps/api/src/invoice/invoice.scheduler.ts
+++ b/apps/api/src/invoice/invoice.scheduler.ts
@@ -1,0 +1,58 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { PrismaService } from '../prisma.service';
+
+/**
+ * Schedules reminders for upcoming and overdue invoices and
+ * applies late fees as line items when thresholds are hit.
+ */
+@Injectable()
+export class InvoiceReminderService {
+  private readonly logger = new Logger(InvoiceReminderService.name);
+  constructor(private readonly prisma: PrismaService) {}
+
+  @Cron(CronExpression.EVERY_DAY_AT_9AM)
+  async handleCron() {
+    const today = new Date();
+    const invoices = await this.prisma.invoice.findMany({
+      where: { paidAt: null },
+      include: { lineItems: true },
+    });
+    for (const invoice of invoices) {
+      const diff = Math.floor(
+        (today.getTime() - invoice.dueDate.getTime()) / 86400000,
+      );
+      switch (diff) {
+        case -3:
+          this.logger.log(`Reminder: invoice ${invoice.id} due in 3 days`);
+          break;
+        case 0:
+          this.logger.log(`Reminder: invoice ${invoice.id} due today`);
+          break;
+        case 3:
+          this.logger.log(`Reminder: invoice ${invoice.id} 3 days overdue`);
+          await this.addLateFee(invoice.id, invoice.lineItems, 1);
+          break;
+        case 7:
+          this.logger.log(`Reminder: invoice ${invoice.id} 7 days overdue`);
+          await this.addLateFee(invoice.id, invoice.lineItems, 2);
+          break;
+      }
+    }
+  }
+
+  private async addLateFee(
+    invoiceId: string,
+    items: { description: string }[],
+    stage: 1 | 2,
+  ) {
+    const description = stage === 1 ? 'Late Fee' : `Late Fee ${stage}`;
+    const exists = items.some((i) => i.description === description);
+    if (exists) return;
+    await this.prisma.invoiceLineItem.create({
+      data: { invoiceId, description, amount: 25 },
+    });
+    this.logger.log(`Applied ${description} to invoice ${invoiceId}`);
+  }
+}
+

--- a/apps/web/app/policies/late-fees/page.tsx
+++ b/apps/web/app/policies/late-fees/page.tsx
@@ -1,0 +1,10 @@
+import { LateFeePolicyEditor } from '../../../components/LateFeePolicyEditor';
+
+export default function LateFeePolicyPage() {
+  return (
+    <div className="p-4">
+      <LateFeePolicyEditor />
+    </div>
+  );
+}
+

--- a/apps/web/components/LateFeePolicyEditor.tsx
+++ b/apps/web/components/LateFeePolicyEditor.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { useState } from 'react';
+import type { LateFeePolicy } from '@tenancy/types';
+
+export function LateFeePolicyEditor() {
+  const [policy, setPolicy] = useState<LateFeePolicy>({
+    firstLateFee: 25,
+    secondLateFee: 25,
+  });
+  return (
+    <div className="space-y-4">
+      <div>
+        <label className="block text-sm font-medium">First late fee (due +3)</label>
+        <input
+          type="number"
+          value={policy.firstLateFee}
+          onChange={(e) =>
+            setPolicy({ ...policy, firstLateFee: Number(e.target.value) })
+          }
+          className="border p-2 rounded w-32"
+        />
+      </div>
+      <div>
+        <label className="block text-sm font-medium">Second late fee (due +7)</label>
+        <input
+          type="number"
+          value={policy.secondLateFee}
+          onChange={(e) =>
+            setPolicy({ ...policy, secondLateFee: Number(e.target.value) })
+          }
+          className="border p-2 rounded w-32"
+        />
+      </div>
+      <div>
+        <h2 className="font-medium">Timeline Preview</h2>
+        <ul className="list-disc pl-5">
+          <li>T-3: Reminder</li>
+          <li>Due: Reminder</li>
+          <li>
+            +3: Reminder &amp; Late Fee $
+            {policy.firstLateFee.toFixed(2)}
+          </li>
+          <li>
+            +7: Reminder &amp; Late Fee $
+            {policy.secondLateFee.toFixed(2)}
+          </li>
+        </ul>
+      </div>
+    </div>
+  );
+}
+

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -13,3 +13,10 @@ export interface Notice {
   acknowledgedAt?: Date;
   createdAt: Date;
 }
+
+export interface LateFeePolicy {
+  /** Amount applied when invoice is 3 days overdue */
+  firstLateFee: number;
+  /** Amount applied when invoice is 7 days overdue */
+  secondLateFee: number;
+}


### PR DESCRIPTION
## Summary
- add scheduler for invoice reminders and late fees
- expose LateFeePolicy type
- add late fee policy editor with timeline preview

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run typecheck` (fails: turbo: not found)


------
https://chatgpt.com/codex/tasks/task_e_68afcdf9f2b4832e876320431f06de76