### PR TITLE
feat: add ledger with csv export

### DIFF
--- a/apps/api/prisma/migrations/006_add_ledger/migration.sql
+++ b/apps/api/prisma/migrations/006_add_ledger/migration.sql
@@ -1,0 +1,10 @@
+CREATE TABLE "LedgerEntry" (
+  "id" TEXT PRIMARY KEY,
+  "orgId" TEXT NOT NULL REFERENCES "Organization"("id") ON DELETE CASCADE,
+  "leaseId" TEXT REFERENCES "Lease"("id") ON DELETE SET NULL,
+  "date" TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "description" TEXT,
+  "debitAccount" TEXT NOT NULL,
+  "creditAccount" TEXT NOT NULL,
+  "amount" DOUBLE PRECISION NOT NULL
+);

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -40,6 +40,11 @@ model Organization {
   Deposit        Deposit[]
   Document       Document[]
   Notification   Notification[]
+  Certificate    Certificate[]
+  Device         Device[]
+  LeaseAmendment LeaseAmendment[]
+  Notice         Notice[]
+  LedgerEntry    LedgerEntry[]
 }
 
 model User {
@@ -234,6 +239,8 @@ model Lease {
   deposits    Deposit[]
   documents   Document[]   @relation("LeaseDocuments")
   amendments  LeaseAmendment[]
+  notices     Notice[]
+  ledgerEntries LedgerEntry[]
   mandates    PaymentMandate[]
   createdAt   DateTime     @default(now())
 }
@@ -425,4 +432,17 @@ model AuditLog {
   action    String
   target    String?
   createdAt DateTime     @default(now())
+}
+
+model LedgerEntry {
+  id           String       @id @default(cuid())
+  org          Organization @relation(fields: [orgId], references: [id])
+  orgId        String
+  lease        Lease?       @relation(fields: [leaseId], references: [id])
+  leaseId      String?
+  date         DateTime     @default(now())
+  description  String?
+  debitAccount String
+  creditAccount String
+  amount       Float
 }

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -42,6 +42,8 @@ import { PaymentService } from './payment/payment.service';
 import { StripeProvider } from './payment/providers/stripe.provider';
 import { PaypalProvider } from './payment/providers/paypal.provider';
 import { SquareProvider } from './payment/providers/square.provider';
+import { LedgerController } from './ledger/ledger.controller';
+import { LedgerService } from './ledger/ledger.service';
 
 @Module({
   imports: [AuthModule, ScheduleModule.forRoot()],
@@ -57,6 +59,7 @@ import { SquareProvider } from './payment/providers/square.provider';
     CertificateController,
     NoticeController,
     PaymentController,
+    LedgerController,
   ],
   providers: [
     AppService,
@@ -89,6 +92,7 @@ import { SquareProvider } from './payment/providers/square.provider';
     StripeProvider,
     PaypalProvider,
     SquareProvider,
+    LedgerService,
   ],
 })
 export class AppModule {}

--- a/apps/api/src/ledger/ledger.controller.ts
+++ b/apps/api/src/ledger/ledger.controller.ts
@@ -1,0 +1,49 @@
+import { Controller, Get, Query, Post, Body, Res } from '@nestjs/common';
+import { LedgerService } from './ledger.service';
+import { Response } from 'express';
+
+@Controller('ledger')
+export class LedgerController {
+  constructor(private ledgerService: LedgerService) {}
+
+  @Get()
+  async getEntries(
+    @Query('orgId') orgId: string,
+    @Query('leaseId') leaseId: string,
+    @Query('start') start: string,
+    @Query('end') end: string,
+  ) {
+    const startDate = start ? new Date(start) : new Date(0);
+    const endDate = end ? new Date(end) : new Date();
+    return this.ledgerService.getEntries(orgId, leaseId, startDate, endDate);
+  }
+
+  @Get('export')
+  async exportCsv(
+    @Query('orgId') orgId: string,
+    @Query('leaseId') leaseId: string,
+    @Query('start') start: string,
+    @Query('end') end: string,
+    @Res() res: Response,
+  ) {
+    const csv = await this.ledgerService.exportCsv(orgId, leaseId, new Date(start), new Date(end));
+    res.setHeader('Content-Type', 'text/csv');
+    res.send(csv);
+  }
+
+  @Post()
+  async create(
+    @Body()
+    body: {
+      orgId: string;
+      leaseId?: string;
+      date?: Date;
+      description?: string;
+      debitAccount: string;
+      creditAccount: string;
+      amount: number;
+    },
+  ) {
+    return this.ledgerService.create(body);
+  }
+}

--- a/apps/api/src/ledger/ledger.service.ts
+++ b/apps/api/src/ledger/ledger.service.ts
@@ -1,0 +1,42 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma.service';
+import { LedgerEntry } from '@prisma/client';
+
+interface CreateLedgerDto {
+  orgId: string;
+  leaseId?: string;
+  date?: Date;
+  description?: string;
+  debitAccount: string;
+  creditAccount: string;
+  amount: number;
+}
+
+@Injectable()
+export class LedgerService {
+  constructor(private prisma: PrismaService) {}
+
+  async create(data: CreateLedgerDto): Promise<LedgerEntry> {
+    return this.prisma.ledgerEntry.create({ data });
+  }
+
+  async getEntries(orgId: string, leaseId: string | undefined, start: Date, end: Date): Promise<LedgerEntry[]> {
+    return this.prisma.ledgerEntry.findMany({
+      where: {
+        orgId,
+        ...(leaseId ? { leaseId } : {}),
+        date: { gte: start, lte: end },
+      },
+      orderBy: { date: 'asc' },
+    });
+  }
+
+  async exportCsv(orgId: string, leaseId: string | undefined, start: Date, end: Date): Promise<string> {
+    const entries = await this.getEntries(orgId, leaseId, start, end);
+    const header = 'date,description,debitAccount,creditAccount,amount';
+    const rows = entries.map(e =>
+      `${e.date.toISOString()},${e.description ?? ''},${e.debitAccount},${e.creditAccount},${e.amount}`,
+    );
+    return [header, ...rows].join('\n');
+  }
+}

--- a/apps/web/app/ledger/page.tsx
+++ b/apps/web/app/ledger/page.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { useState } from 'react';
+import { Button } from '@tenancy/ui';
+
+export default function LedgerPage() {
+  const [start, setStart] = useState('');
+  const [end, setEnd] = useState('');
+  const [entries, setEntries] = useState<any[]>([]);
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001';
+
+  const fetchEntries = async () => {
+    const res = await fetch(`${apiUrl}/ledger?start=${start}&end=${end}`);
+    const data = await res.json();
+    setEntries(data);
+  };
+
+  const downloadCsv = async () => {
+    const res = await fetch(`${apiUrl}/ledger/export?start=${start}&end=${end}`);
+    const blob = await res.blob();
+    const url = window.URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'ledger.csv';
+    a.click();
+    window.URL.revokeObjectURL(url);
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="space-x-2">
+        <input type="date" value={start} onChange={e => setStart(e.target.value)} />
+        <input type="date" value={end} onChange={e => setEnd(e.target.value)} />
+        <Button onClick={fetchEntries}>Filter</Button>
+        <Button onClick={downloadCsv}>Download CSV</Button>
+      </div>
+      <table className="min-w-full text-sm">
+        <thead>
+          <tr>
+            <th>Date</th>
+            <th>Description</th>
+            <th>Debit</th>
+            <th>Credit</th>
+            <th>Amount</th>
+          </tr>
+        </thead>
+        <tbody>
+          {entries.map(entry => (
+            <tr key={entry.id}>
+              <td>{new Date(entry.date).toLocaleDateString()}</td>
+              <td>{entry.description}</td>
+              <td>{entry.debitAccount}</td>
+              <td>{entry.creditAccount}</td>
+              <td>{entry.amount}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -20,3 +20,14 @@ export interface LateFeePolicy {
   /** Amount applied when invoice is 7 days overdue */
   secondLateFee: number;
 }
+
+export interface LedgerEntry {
+  id: string;
+  orgId: string;
+  leaseId?: string;
+  date: Date;
+  description?: string;
+  debitAccount: string;
+  creditAccount: string;
+  amount: number;
+}


### PR DESCRIPTION
## Summary
- add LedgerEntry model, migration, and double-entry service/controller
- expose ledger filtering and CSV export
- web page to filter ledger by date and download CSV

## Testing
- `npm test` (api)
- `npm test` (web, fails: Missing script "test")
- `npx -y prisma generate` (fails: Command failed with exit code 1: npm i prisma@6.15.0 -D --silent)


------
https://chatgpt.com/codex/tasks/task_e_68afcf96429c832e96a5b9d541f41fd1