### PR TITLE
feat: add subletting approvals and payouts

### DIFF
--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -19,34 +19,37 @@ enum Role {
 }
 
 model Organization {
-  id             String           @id @default(cuid())
-  name           String
-  createdAt      DateTime         @default(now())
-  memberships    Membership[]
-  properties     Property[]
-  apiKeys        ApiKey[]
-  plans          Plan[]
-  featureFlags   FeatureFlag[]
-  auditLogs      AuditLog[]
-  Unit           Unit[]
-  Household      Household[]
-  Lease          Lease[]
-  Invoice        Invoice[]
-  Payment        Payment[]
-  paymentMandates PaymentMandate[]
-  Ticket         Ticket[]
-  Visit          Visit[]
-  UtilityReading UtilityReading[]
-  Deposit        Deposit[]
-  Document       Document[]
-  Notification   Notification[]
-  Certificate    Certificate[]
-  Device         Device[]
-  LeaseAmendment LeaseAmendment[]
-  Notice         Notice[]
-  LedgerEntry    LedgerEntry[]
-  LeaseShare     LeaseShare[]
-  InvoiceShare   InvoiceShare[]
+  id                 String               @id @default(cuid())
+  name               String
+  createdAt          DateTime             @default(now())
+  memberships        Membership[]
+  properties         Property[]
+  apiKeys            ApiKey[]
+  plans              Plan[]
+  featureFlags       FeatureFlag[]
+  auditLogs          AuditLog[]
+  Unit               Unit[]
+  Household          Household[]
+  Lease              Lease[]
+  Invoice            Invoice[]
+  Payment            Payment[]
+  paymentMandates    PaymentMandate[]
+  Ticket             Ticket[]
+  Visit              Visit[]
+  UtilityReading     UtilityReading[]
+  Deposit            Deposit[]
+  Document           Document[]
+  Notification       Notification[]
+  Certificate        Certificate[]
+  Device             Device[]
+  LeaseAmendment     LeaseAmendment[]
+  Notice             Notice[]
+  LedgerEntry        LedgerEntry[]
+  LeaseShare         LeaseShare[]
+  InvoiceShare       InvoiceShare[]
+  SublettingApproval SublettingApproval[]
+  AirbnbIntegration  AirbnbIntegration[]
+  SublettingPayout   SublettingPayout[]
 }
 
 model User {
@@ -101,53 +104,53 @@ model VerificationToken {
 }
 
 model Membership {
-  id         String       @id @default(cuid())
-  org        Organization @relation(fields: [orgId], references: [id])
-  orgId      String
-  user       User         @relation(fields: [userId], references: [id])
-  userId     String
-  role       Role
-  createdAt  DateTime     @default(now())
-  households Household[]  @relation("HouseholdMembers")
-  Ticket     Ticket[]
-  LeaseShare LeaseShare[]
+  id           String         @id @default(cuid())
+  org          Organization   @relation(fields: [orgId], references: [id])
+  orgId        String
+  user         User           @relation(fields: [userId], references: [id])
+  userId       String
+  role         Role
+  createdAt    DateTime       @default(now())
+  households   Household[]    @relation("HouseholdMembers")
+  Ticket       Ticket[]
+  LeaseShare   LeaseShare[]
   InvoiceShare InvoiceShare[]
 }
 
 model Property {
-  id        String       @id @default(cuid())
-  org       Organization @relation(fields: [orgId], references: [id])
-  orgId     String
-  name      String
-  address   String?
-  units     Unit[]
-  visits    Visit[]
-  tickets   Ticket[]
+  id           String        @id @default(cuid())
+  org          Organization  @relation(fields: [orgId], references: [id])
+  orgId        String
+  name         String
+  address      String?
+  units        Unit[]
+  visits       Visit[]
+  tickets      Ticket[]
   certificates Certificate[]
-  createdAt DateTime     @default(now())
-  imageUrl  String?
-  deletedAt DateTime?
+  createdAt    DateTime      @default(now())
+  imageUrl     String?
+  deletedAt    DateTime?
 }
 
 model Unit {
-  id              String           @id @default(cuid())
-  org             Organization     @relation(fields: [orgId], references: [id])
-  orgId           String
-  property        Property         @relation(fields: [propertyId], references: [id])
-  propertyId      String
-  name            String
-  households      Household[]
-  leases          Lease[]
-  utilityReadings UtilityReading[]
-  tickets         Ticket[]
-  visits          Visit[]
-  devices         Device[]
-  certificates   Certificate[]
-  createdAt       DateTime         @default(now())
-  imageUrl        String?
+  id                  String           @id @default(cuid())
+  org                 Organization     @relation(fields: [orgId], references: [id])
+  orgId               String
+  property            Property         @relation(fields: [propertyId], references: [id])
+  propertyId          String
+  name                String
+  households          Household[]
+  leases              Lease[]
+  utilityReadings     UtilityReading[]
+  tickets             Ticket[]
+  visits              Visit[]
+  devices             Device[]
+  certificates        Certificate[]
+  createdAt           DateTime         @default(now())
+  imageUrl            String?
   virtualTourEmbedUrl String?
-  virtualTourImages  String[]      @default([])
-  deletedAt       DateTime?
+  virtualTourImages   String[]         @default([])
+  deletedAt           DateTime?
 }
 
 enum CertificateType {
@@ -157,17 +160,17 @@ enum CertificateType {
 }
 
 model Certificate {
-  id         String           @id @default(cuid())
-  org        Organization     @relation(fields: [orgId], references: [id])
+  id         String          @id @default(cuid())
+  org        Organization    @relation(fields: [orgId], references: [id])
   orgId      String
-  property   Property?        @relation(fields: [propertyId], references: [id])
+  property   Property?       @relation(fields: [propertyId], references: [id])
   propertyId String?
-  unit       Unit?            @relation(fields: [unitId], references: [id])
+  unit       Unit?           @relation(fields: [unitId], references: [id])
   unitId     String?
   type       CertificateType
   expiryDate DateTime
   fileUrl    String?
-  createdAt  DateTime         @default(now())
+  createdAt  DateTime        @default(now())
 }
 
 enum DeviceType {
@@ -228,31 +231,32 @@ enum ShareType {
 }
 
 model Lease {
-  id          String       @id @default(cuid())
-  org         Organization @relation(fields: [orgId], references: [id])
-  orgId       String
-  unit        Unit         @relation(fields: [unitId], references: [id])
-  unitId      String
-  household   Household    @relation(fields: [householdId], references: [id])
-  householdId String
-  startDate   DateTime
-  endDate     DateTime?
-  rentAmount  Float
-  rentFrequency RentFrequency
-  depositAmount Float?
-  utilityAllowances Json?
-  autoRenew   Boolean      @default(false)
-  breakClause String?
-  status      LeaseStatus  @default(draft)
-  invoices    Invoice[]
-  deposits    Deposit[]
-  documents   Document[]   @relation("LeaseDocuments")
-  amendments  LeaseAmendment[]
-  notices     Notice[]
-  ledgerEntries LedgerEntry[]
-  mandates    PaymentMandate[]
-  shares      LeaseShare[]
-  createdAt   DateTime     @default(now())
+  id                 String               @id @default(cuid())
+  org                Organization         @relation(fields: [orgId], references: [id])
+  orgId              String
+  unit               Unit                 @relation(fields: [unitId], references: [id])
+  unitId             String
+  household          Household            @relation(fields: [householdId], references: [id])
+  householdId        String
+  startDate          DateTime
+  endDate            DateTime?
+  rentAmount         Float
+  rentFrequency      RentFrequency
+  depositAmount      Float?
+  utilityAllowances  Json?
+  autoRenew          Boolean              @default(false)
+  breakClause        String?
+  status             LeaseStatus          @default(draft)
+  invoices           Invoice[]
+  deposits           Deposit[]
+  documents          Document[]           @relation("LeaseDocuments")
+  amendments         LeaseAmendment[]
+  notices            Notice[]
+  ledgerEntries      LedgerEntry[]
+  mandates           PaymentMandate[]
+  shares             LeaseShare[]
+  createdAt          DateTime             @default(now())
+  SublettingApproval SublettingApproval[]
 }
 
 model LeaseShare {
@@ -284,10 +288,10 @@ model LeaseAmendment {
 }
 
 model Invoice {
-  id        String       @id @default(cuid())
-  org       Organization @relation(fields: [orgId], references: [id])
+  id        String            @id @default(cuid())
+  org       Organization      @relation(fields: [orgId], references: [id])
   orgId     String
-  lease     Lease        @relation(fields: [leaseId], references: [id])
+  lease     Lease             @relation(fields: [leaseId], references: [id])
   leaseId   String
   subtotal  Float
   tax       Float
@@ -296,7 +300,7 @@ model Invoice {
   payments  Payment[]
   lineItems InvoiceLineItem[]
   shares    InvoiceShare[]
-  createdAt DateTime     @default(now())
+  createdAt DateTime          @default(now())
   paidAt    DateTime?
 }
 
@@ -312,8 +316,8 @@ model InvoiceShare {
 }
 
 model InvoiceLineItem {
-  id          String   @id @default(cuid())
-  invoice     Invoice  @relation(fields: [invoiceId], references: [id])
+  id          String  @id @default(cuid())
+  invoice     Invoice @relation(fields: [invoiceId], references: [id])
   invoiceId   String
   description String
   amount      Float
@@ -321,27 +325,27 @@ model InvoiceLineItem {
 }
 
 model Payment {
-  id        String       @id @default(cuid())
-  org       Organization @relation(fields: [orgId], references: [id])
-  orgId     String
-  invoice   Invoice      @relation(fields: [invoiceId], references: [id])
-  invoiceId String
-  provider  String
-  externalId String @unique
-  amount    Float
-  paidAt    DateTime     @default(now())
+  id         String       @id @default(cuid())
+  org        Organization @relation(fields: [orgId], references: [id])
+  orgId      String
+  invoice    Invoice      @relation(fields: [invoiceId], references: [id])
+  invoiceId  String
+  provider   String
+  externalId String       @unique
+  amount     Float
+  paidAt     DateTime     @default(now())
 }
 
 model PaymentMandate {
-  id        String       @id @default(cuid())
-  org       Organization @relation(fields: [orgId], references: [id])
-  orgId     String
-  lease     Lease        @relation(fields: [leaseId], references: [id])
-  leaseId   String
-  provider  String
+  id         String       @id @default(cuid())
+  org        Organization @relation(fields: [orgId], references: [id])
+  orgId      String
+  lease      Lease        @relation(fields: [leaseId], references: [id])
+  leaseId    String
+  provider   String
   externalId String
-  active    Boolean      @default(true)
-  createdAt DateTime     @default(now())
+  active     Boolean      @default(true)
+  createdAt  DateTime     @default(now())
 }
 
 model Ticket {
@@ -410,15 +414,15 @@ model Document {
 }
 
 model Notice {
-  id            String       @id @default(cuid())
-  org           Organization @relation(fields: [orgId], references: [id])
-  orgId         String
-  lease         Lease        @relation(fields: [leaseId], references: [id])
-  leaseId       String
-  type          String
-  pdfUrl        String
+  id             String       @id @default(cuid())
+  org            Organization @relation(fields: [orgId], references: [id])
+  orgId          String
+  lease          Lease        @relation(fields: [leaseId], references: [id])
+  leaseId        String
+  type           String
+  pdfUrl         String
   acknowledgedAt DateTime?
-  createdAt     DateTime     @default(now())
+  createdAt      DateTime     @default(now())
 }
 
 model Notification {
@@ -469,14 +473,45 @@ model AuditLog {
 }
 
 model LedgerEntry {
-  id           String       @id @default(cuid())
-  org          Organization @relation(fields: [orgId], references: [id])
-  orgId        String
-  lease        Lease?       @relation(fields: [leaseId], references: [id])
-  leaseId      String?
-  date         DateTime     @default(now())
-  description  String?
-  debitAccount String
+  id            String       @id @default(cuid())
+  org           Organization @relation(fields: [orgId], references: [id])
+  orgId         String
+  lease         Lease?       @relation(fields: [leaseId], references: [id])
+  leaseId       String?
+  date          DateTime     @default(now())
+  description   String?
+  debitAccount  String
   creditAccount String
-  amount       Float
+  amount        Float
+}
+
+model SublettingApproval {
+  id           String             @id @default(cuid())
+  org          Organization       @relation(fields: [orgId], references: [id])
+  orgId        String
+  lease        Lease              @relation(fields: [leaseId], references: [id])
+  leaseId      String
+  revenueShare Float
+  createdAt    DateTime           @default(now())
+  payouts      SublettingPayout[]
+}
+
+model AirbnbIntegration {
+  id        String       @id @default(cuid())
+  org       Organization @relation(fields: [orgId], references: [id])
+  orgId     String
+  listingId String
+  active    Boolean      @default(true)
+  createdAt DateTime     @default(now())
+}
+
+model SublettingPayout {
+  id          String             @id @default(cuid())
+  org         Organization       @relation(fields: [orgId], references: [id])
+  orgId       String
+  approval    SublettingApproval @relation(fields: [approvalId], references: [id])
+  approvalId  String
+  amount      Float
+  platformFee Float
+  createdAt   DateTime           @default(now())
 }

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -45,6 +45,8 @@ import { PaypalProvider } from './payment/providers/paypal.provider';
 import { SquareProvider } from './payment/providers/square.provider';
 import { LedgerController } from './ledger/ledger.controller';
 import { LedgerService } from './ledger/ledger.service';
+import { SublettingController } from './subletting/subletting.controller';
+import { SublettingService } from './subletting/subletting.service';
 
 @Module({
   imports: [AuthModule, ScheduleModule.forRoot()],
@@ -62,6 +64,7 @@ import { LedgerService } from './ledger/ledger.service';
     InvoiceController,
     PaymentController,
     LedgerController,
+    SublettingController,
   ],
   providers: [
     AppService,
@@ -95,6 +98,7 @@ import { LedgerService } from './ledger/ledger.service';
     PaypalProvider,
     SquareProvider,
     LedgerService,
+    SublettingService,
   ],
 })
 export class AppModule {}

--- a/apps/api/src/subletting/subletting.controller.ts
+++ b/apps/api/src/subletting/subletting.controller.ts
@@ -1,0 +1,32 @@
+import { Body, Controller, Param, Post } from '@nestjs/common';
+import { SublettingService } from './subletting.service';
+
+@Controller('subletting')
+export class SublettingController {
+  constructor(private readonly sublettingService: SublettingService) {}
+
+  @Post(':leaseId/approval')
+  approve(
+    @Param('leaseId') leaseId: string,
+    @Body('revenueShare') revenueShare: number,
+  ) {
+    return this.sublettingService.approve(leaseId, revenueShare);
+  }
+
+  @Post('airbnb/:orgId')
+  integrateAirbnb(
+    @Param('orgId') orgId: string,
+    @Body('listingId') listingId: string,
+  ) {
+    return this.sublettingService.integrateAirbnb(orgId, listingId);
+  }
+
+  @Post('payout/:approvalId')
+  payout(
+    @Param('approvalId') approvalId: string,
+    @Body('amount') amount: number,
+  ) {
+    return this.sublettingService.recordPayout(approvalId, amount);
+  }
+}
+

--- a/apps/api/src/subletting/subletting.service.ts
+++ b/apps/api/src/subletting/subletting.service.ts
@@ -1,0 +1,58 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma.service';
+import { LedgerService } from '../ledger/ledger.service';
+
+@Injectable()
+export class SublettingService {
+  constructor(private prisma: PrismaService, private ledger: LedgerService) {}
+
+  async approve(leaseId: string, revenueShare: number) {
+    const lease = await this.prisma.lease.findUnique({ where: { id: leaseId } });
+    if (!lease) throw new Error('Lease not found');
+    const prisma = this.prisma as any;
+    return prisma.sublettingApproval.create({
+      data: { orgId: lease.orgId, leaseId, revenueShare },
+    });
+  }
+
+  async integrateAirbnb(orgId: string, listingId: string) {
+    const prisma = this.prisma as any;
+    return prisma.airbnbIntegration.create({
+      data: { orgId, listingId, active: true },
+    });
+  }
+
+  async recordPayout(approvalId: string, amount: number) {
+    const prisma = this.prisma as any;
+    const approval = await prisma.sublettingApproval.findUnique({ where: { id: approvalId } });
+    if (!approval) throw new Error('Approval not found');
+    const platformFee = amount * approval.revenueShare;
+    const payoutAmount = amount - platformFee;
+    const payout = await prisma.sublettingPayout.create({
+      data: {
+        orgId: approval.orgId,
+        approvalId,
+        amount: payoutAmount,
+        platformFee,
+      },
+    });
+    await this.ledger.create({
+      orgId: approval.orgId,
+      date: new Date(),
+      description: 'Subletting payout',
+      debitAccount: 'subletting_payout',
+      creditAccount: 'cash',
+      amount: payoutAmount,
+    });
+    await this.ledger.create({
+      orgId: approval.orgId,
+      date: new Date(),
+      description: 'Platform fee',
+      debitAccount: 'cash',
+      creditAccount: 'platform_fee_income',
+      amount: platformFee,
+    });
+    return payout;
+  }
+}
+

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -31,3 +31,28 @@ export interface LedgerEntry {
   creditAccount: string;
   amount: number;
 }
+
+export interface SublettingApproval {
+  id: string;
+  orgId: string;
+  leaseId: string;
+  revenueShare: number;
+  createdAt: Date;
+}
+
+export interface AirbnbIntegration {
+  id: string;
+  orgId: string;
+  listingId: string;
+  active: boolean;
+  createdAt: Date;
+}
+
+export interface SublettingPayout {
+  id: string;
+  orgId: string;
+  approvalId: string;
+  amount: number;
+  platformFee: number;
+  createdAt: Date;
+}


### PR DESCRIPTION
## Summary
- add subletting approvals with revenue share terms
- track mock Airbnb integrations and record payouts with platform fees
- expose subletting endpoints and post related ledger entries

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: turbo: not found)*
- `npm run typecheck` *(fails: turbo: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aff93c4454832ebf2a2eef4034c1ae