### PR TITLE
feat: add payment plan scheduling

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -8,7 +8,7 @@
     "start": "node dist/main.js",
     "lint": "eslint 'src/**/*.{ts,tsx}'",
     "typecheck": "tsc --noEmit",
-    "test": "tsc src/invoice/invoice.utils.ts src/invoice/invoice.service.spec.ts --module commonjs --target es2019 --outDir dist-test --esModuleInterop --skipLibCheck && node dist-test/invoice.service.spec.js"
+    "test": "tsc src/invoice/invoice.utils.ts src/invoice/invoice.service.spec.ts src/payment/payment-plan.service.spec.ts --module commonjs --target es2019 --outDir dist-test --esModuleInterop --skipLibCheck && node dist-test/invoice.service.spec.js && node dist-test/payment-plan.service.spec.js"
   },
   "dependencies": {
     "@nestjs/common": "^10.2.5",

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -40,6 +40,7 @@ import { InvoiceReminderService } from './invoice/invoice.scheduler';
 import { InvoiceController } from './invoice/invoice.controller';
 import { PaymentController } from './payment/payment.controller';
 import { PaymentService } from './payment/payment.service';
+import { PaymentPlanService } from './payment/payment-plan.service';
 import { StripeProvider } from './payment/providers/stripe.provider';
 import { PaypalProvider } from './payment/providers/paypal.provider';
 import { SquareProvider } from './payment/providers/square.provider';
@@ -94,6 +95,7 @@ import { SublettingService } from './subletting/subletting.service';
     InvoiceService,
     InvoiceReminderService,
     PaymentService,
+    PaymentPlanService,
     StripeProvider,
     PaypalProvider,
     SquareProvider,

--- a/apps/api/src/payment/payment-plan.service.spec.ts
+++ b/apps/api/src/payment/payment-plan.service.spec.ts
@@ -1,0 +1,22 @@
+import assert from 'assert';
+import { PaymentPlanService } from './payment-plan.service';
+
+async function runTests() {
+  const service = new PaymentPlanService();
+  const start = new Date('2024-01-01');
+  const schedule = service.generateSchedule(1000, 0.1, 2, start);
+  assert.strictEqual(schedule.length, 2);
+  assert.ok(Math.abs(schedule[0].amount - 550) < 0.01);
+  assert.strictEqual(schedule[0].dueDate.getMonth(), 0);
+  assert.strictEqual(schedule[1].dueDate.getMonth(), 1);
+
+  service.autoDebitDuePayments(schedule, new Date('2024-01-15'));
+  assert.ok(schedule[0].paid);
+
+  service.markMissedAsDunning(schedule, new Date('2024-02-15'));
+  assert.ok(schedule[1].inDunning);
+
+  console.log('PaymentPlanService tests passed');
+}
+
+runTests();

--- a/apps/api/src/payment/payment-plan.service.ts
+++ b/apps/api/src/payment/payment-plan.service.ts
@@ -1,0 +1,39 @@
+import { Injectable } from '@nestjs/common';
+import { PaymentScheduleItem } from '@tenancy/types';
+
+@Injectable()
+export class PaymentPlanService {
+  generateSchedule(
+    principal: number,
+    interestRate: number,
+    installments: number,
+    startDate: Date,
+  ): PaymentScheduleItem[] {
+    const totalInterest = principal * interestRate;
+    const total = principal + totalInterest;
+    const installmentAmount = Math.round((total / installments) * 100) / 100;
+    const schedule: PaymentScheduleItem[] = [];
+    for (let i = 0; i < installments; i++) {
+      const dueDate = new Date(startDate);
+      dueDate.setMonth(dueDate.getMonth() + i);
+      schedule.push({ dueDate, amount: installmentAmount, paid: false });
+    }
+    return schedule;
+  }
+
+  autoDebitDuePayments(schedule: PaymentScheduleItem[], today = new Date()): void {
+    schedule.forEach((item) => {
+      if (!item.paid && item.dueDate <= today) {
+        item.paid = true;
+      }
+    });
+  }
+
+  markMissedAsDunning(schedule: PaymentScheduleItem[], today = new Date()): void {
+    schedule.forEach((item) => {
+      if (!item.paid && item.dueDate < today) {
+        item.inDunning = true;
+      }
+    });
+  }
+}

--- a/apps/web/app/payment-plans/page.tsx
+++ b/apps/web/app/payment-plans/page.tsx
@@ -1,0 +1,10 @@
+import PlanBuilder from '@/components/PlanBuilder';
+
+export default function PaymentPlansPage() {
+  return (
+    <div className="p-4">
+      <h1 className="text-xl mb-4">Payment Plan Builder</h1>
+      <PlanBuilder />
+    </div>
+  );
+}

--- a/apps/web/components/PlanBuilder.tsx
+++ b/apps/web/components/PlanBuilder.tsx
@@ -1,0 +1,62 @@
+'use client';
+import { useState } from 'react';
+import { PaymentScheduleItem } from '@tenancy/types';
+import { generateSchedule } from '@/lib/paymentPlan';
+import SchedulePreview from './SchedulePreview';
+
+export default function PlanBuilder() {
+  const [amount, setAmount] = useState(0);
+  const [interest, setInterest] = useState(0);
+  const [installments, setInstallments] = useState(1);
+  const [startDate, setStartDate] = useState('');
+  const [schedule, setSchedule] = useState<PaymentScheduleItem[]>([]);
+
+  function updateSchedule() {
+    if (!startDate) return;
+    setSchedule(
+      generateSchedule(amount, interest, installments, new Date(startDate)),
+    );
+  }
+
+  return (
+    <div>
+      <div className="flex flex-col gap-2 max-w-sm">
+        <input
+          type="number"
+          value={amount}
+          onChange={(e) => setAmount(parseFloat(e.target.value))}
+          placeholder="Amount"
+          className="border p-1"
+        />
+        <input
+          type="number"
+          step="0.01"
+          value={interest}
+          onChange={(e) => setInterest(parseFloat(e.target.value))}
+          placeholder="Interest rate"
+          className="border p-1"
+        />
+        <input
+          type="number"
+          value={installments}
+          onChange={(e) => setInstallments(parseInt(e.target.value))}
+          placeholder="Installments"
+          className="border p-1"
+        />
+        <input
+          type="date"
+          value={startDate}
+          onChange={(e) => setStartDate(e.target.value)}
+          className="border p-1"
+        />
+        <button
+          onClick={updateSchedule}
+          className="px-2 py-1 bg-blue-600 text-white"
+        >
+          Preview
+        </button>
+      </div>
+      <SchedulePreview schedule={schedule} />
+    </div>
+  );
+}

--- a/apps/web/components/SchedulePreview.tsx
+++ b/apps/web/components/SchedulePreview.tsx
@@ -1,0 +1,33 @@
+import { PaymentScheduleItem } from '@tenancy/types';
+
+export default function SchedulePreview({
+  schedule,
+}: {
+  schedule: PaymentScheduleItem[];
+}) {
+  if (!schedule.length) return null;
+  return (
+    <table className="mt-4 w-full text-left border">
+      <thead>
+        <tr>
+          <th className="border px-2">Due Date</th>
+          <th className="border px-2">Amount</th>
+          <th className="border px-2">Status</th>
+        </tr>
+      </thead>
+      <tbody>
+        {schedule.map((item, idx) => (
+          <tr key={idx} className="border-t">
+            <td className="px-2">
+              {item.dueDate.toISOString().slice(0, 10)}
+            </td>
+            <td className="px-2">{item.amount.toFixed(2)}</td>
+            <td className="px-2">
+              {item.paid ? 'Paid' : item.inDunning ? 'Dunning' : 'Pending'}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/apps/web/lib/paymentPlan.ts
+++ b/apps/web/lib/paymentPlan.ts
@@ -1,0 +1,19 @@
+import { PaymentScheduleItem } from '@tenancy/types';
+
+export function generateSchedule(
+  principal: number,
+  interestRate: number,
+  installments: number,
+  startDate: Date,
+): PaymentScheduleItem[] {
+  const totalInterest = principal * interestRate;
+  const total = principal + totalInterest;
+  const installmentAmount = Math.round((total / installments) * 100) / 100;
+  const schedule: PaymentScheduleItem[] = [];
+  for (let i = 0; i < installments; i++) {
+    const dueDate = new Date(startDate);
+    dueDate.setMonth(dueDate.getMonth() + i);
+    schedule.push({ dueDate, amount: installmentAmount, paid: false });
+  }
+  return schedule;
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -56,3 +56,14 @@ export interface SublettingPayout {
   platformFee: number;
   createdAt: Date;
 }
+
+export interface PaymentScheduleItem {
+  /** Date when the installment is due */
+  dueDate: Date;
+  /** Amount to be charged on the due date */
+  amount: number;
+  /** Whether the installment has been successfully paid */
+  paid: boolean;
+  /** Flag indicating the installment has moved to dunning */
+  inDunning?: boolean;
+}


### PR DESCRIPTION
## Summary
- add payment plan service for interest-bearing schedules
- expose plan builder and schedule preview UI

## Testing
- `pnpm lint` *(fails: turbo: not found)*
- `tsc apps/api/src/invoice/invoice.utils.ts apps/api/src/invoice/invoice.service.spec.ts apps/api/src/payment/payment-plan.service.spec.ts --module commonjs --target es2019 --outDir apps/api/dist-test --esModuleInterop --skipLibCheck && node apps/api/dist-test/invoice.service.spec.js && node apps/api/dist-test/payment-plan.service.spec.js` *(fails: Cannot find module 'assert'; Cannot find module '@nestjs/common')*

------
https://chatgpt.com/codex/tasks/task_e_68affd4dbad0832e87a5cf39a62a7868