### PR TITLE
feat: ticket model and kanban board

### DIFF
--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -35,6 +35,8 @@ model Organization {
   Payment            Payment[]
   paymentMandates    PaymentMandate[]
   Ticket             Ticket[]
+  TicketCategory     TicketCategory[]
+  TicketNote         TicketNote[]
   Visit              Visit[]
   UtilityReading     UtilityReading[]
   Deposit            Deposit[]
@@ -113,6 +115,7 @@ model Membership {
   createdAt    DateTime       @default(now())
   households   Household[]    @relation("HouseholdMembers")
   Ticket       Ticket[]
+  TicketNote   TicketNote[]
   LeaseShare   LeaseShare[]
   InvoiceShare InvoiceShare[]
 }
@@ -357,12 +360,57 @@ model Ticket {
   createdBy   Membership?  @relation(fields: [createdById], references: [id])
   createdById String?
   description String
-  status      String
+  type        TicketType
+  priority    TicketPriority
+  status      TicketStatus   @default(open)
+  category    TicketCategory @relation(fields: [categoryId], references: [id])
+  categoryId  String?
+  notes       TicketNote[]
   visits      Visit[]
   documents   Document[]   @relation("TicketDocuments")
   createdAt   DateTime     @default(now())
   Property    Property?    @relation(fields: [propertyId], references: [id])
   propertyId  String?
+}
+
+enum TicketType {
+  maintenance
+  support
+  other
+}
+
+enum TicketPriority {
+  low
+  medium
+  high
+}
+
+enum TicketStatus {
+  open
+  in_progress
+  completed
+}
+
+model TicketCategory {
+  id       String       @id @default(cuid())
+  org      Organization @relation(fields: [orgId], references: [id])
+  orgId    String
+  name     String
+  slaHours Int
+  tickets  Ticket[]
+}
+
+model TicketNote {
+  id        String       @id @default(cuid())
+  org       Organization @relation(fields: [orgId], references: [id])
+  orgId     String
+  ticket    Ticket       @relation(fields: [ticketId], references: [id])
+  ticketId  String
+  author    Membership?  @relation(fields: [authorId], references: [id])
+  authorId  String?
+  content   String
+  internal  Boolean      @default(false)
+  createdAt DateTime     @default(now())
 }
 
 model Visit {

--- a/apps/web/app/tickets/page.tsx
+++ b/apps/web/app/tickets/page.tsx
@@ -1,0 +1,64 @@
+import { Ticket, TicketStatus } from 'types';
+
+async function fetchTickets(): Promise<Ticket[]> {
+  const res = await fetch(
+    `${process.env.NEXT_PUBLIC_API_URL}/tickets`,
+    { cache: 'no-store' },
+  );
+  if (!res.ok) {
+    return [];
+  }
+  return res.json();
+}
+
+function SlaBadge({ ticket }: { ticket: Ticket }) {
+  const slaHours = ticket.category?.slaHours ?? 0;
+  if (!slaHours) return null;
+  const deadline = new Date(ticket.createdAt);
+  deadline.setHours(deadline.getHours() + slaHours);
+  const diffMs = deadline.getTime() - Date.now();
+  const hoursLeft = Math.ceil(diffMs / 3600000);
+  const expired = diffMs < 0;
+  const bg = expired ? '#dc2626' : '#16a34a';
+  return (
+    <span style={{ backgroundColor: bg, color: 'white', padding: '2px 4px', borderRadius: 4 }}>
+      {hoursLeft}h
+    </span>
+  );
+}
+
+export default async function TicketsPage() {
+  const tickets = await fetchTickets();
+  const columns: Record<TicketStatus, Ticket[]> = {
+    open: [],
+    in_progress: [],
+    completed: [],
+  };
+  tickets.forEach((t) => {
+    columns[t.status].push(t);
+  });
+  return (
+    <div style={{ display: 'flex', gap: '1rem' }}>
+      {Object.entries(columns).map(([status, items]) => (
+        <div key={status} style={{ flex: 1 }}>
+          <h2 style={{ textTransform: 'capitalize' }}>{status.replace('_', ' ')}</h2>
+          {items.map((t) => (
+            <div
+              key={t.id}
+              style={{
+                border: '1px solid #ddd',
+                padding: '0.5rem',
+                marginBottom: '0.5rem',
+                borderRadius: '4px',
+                background: 'white',
+              }}
+            >
+              <p>{t.description}</p>
+              <SlaBadge ticket={t} />
+            </div>
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -67,3 +67,39 @@ export interface PaymentScheduleItem {
   /** Flag indicating the installment has moved to dunning */
   inDunning?: boolean;
 }
+
+export type TicketStatus = 'open' | 'in_progress' | 'completed';
+export type TicketPriority = 'low' | 'medium' | 'high';
+export type TicketType = 'maintenance' | 'support' | 'other';
+
+export interface TicketCategory {
+  id: string;
+  orgId: string;
+  name: string;
+  slaHours: number;
+}
+
+export interface TicketNote {
+  id: string;
+  orgId: string;
+  ticketId: string;
+  authorId?: string;
+  content: string;
+  internal: boolean;
+  createdAt: Date;
+}
+
+export interface Ticket {
+  id: string;
+  orgId: string;
+  unitId: string;
+  createdById?: string;
+  description: string;
+  type: TicketType;
+  priority: TicketPriority;
+  status: TicketStatus;
+  categoryId?: string;
+  category?: TicketCategory;
+  notes: TicketNote[];
+  createdAt: Date;
+}


### PR DESCRIPTION
## Summary
- extend Prisma schema with ticket types, priority, status, categories, and notes
- add shared types for tickets
- add basic tickets page with kanban board and SLA badges

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: turbo not found)
- `npm install` (fails: Unsupported URL Type "workspace:")
- `yarn install` (fails: No candidates found for @shadcn/ui)


------
https://chatgpt.com/codex/tasks/task_e_68afff0c36a0832e954d84132af706b8