### PR TITLE
feat: enhance tickets workflow

### DIFF
--- a/apps/api/prisma/migrations/002_ticket_enhancements/migration.sql
+++ b/apps/api/prisma/migrations/002_ticket_enhancements/migration.sql
@@ -1,0 +1,14 @@
+-- CreateEnum
+CREATE TYPE "AssignmentStatus" AS ENUM ('pending', 'accepted', 'declined');
+
+-- AlterTable
+ALTER TABLE "Ticket" ADD COLUMN "assignedToId" TEXT,
+ADD COLUMN "assignmentStatus" "AssignmentStatus" NOT NULL DEFAULT 'pending',
+ADD COLUMN "eta" TIMESTAMP(3),
+ADD COLUMN "partsCost" DOUBLE PRECISION DEFAULT 0,
+ADD COLUMN "labourCost" DOUBLE PRECISION DEFAULT 0,
+ADD COLUMN "rating" INTEGER,
+ADD COLUMN "review" TEXT;
+
+-- AddForeignKey
+ALTER TABLE "Ticket" ADD CONSTRAINT "Ticket_assignedToId_fkey" FOREIGN KEY ("assignedToId") REFERENCES "Membership"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -115,6 +115,7 @@ model Membership {
   createdAt    DateTime       @default(now())
   households   Household[]    @relation("HouseholdMembers")
   Ticket       Ticket[]
+  assignedTickets Ticket[] @relation("TicketAssignedTo")
   TicketNote   TicketNote[]
   LeaseShare   LeaseShare[]
   InvoiceShare InvoiceShare[]
@@ -365,6 +366,14 @@ model Ticket {
   status      TicketStatus   @default(open)
   category    TicketCategory @relation(fields: [categoryId], references: [id])
   categoryId  String?
+  assignedTo   Membership?    @relation("TicketAssignedTo", fields: [assignedToId], references: [id])
+  assignedToId String?
+  assignmentStatus AssignmentStatus @default(pending)
+  eta         DateTime?
+  partsCost   Float?      @default(0)
+  labourCost  Float?      @default(0)
+  rating      Int?
+  review      String?
   notes       TicketNote[]
   visits      Visit[]
   documents   Document[]   @relation("TicketDocuments")
@@ -389,6 +398,12 @@ enum TicketStatus {
   open
   in_progress
   completed
+}
+
+enum AssignmentStatus {
+  pending
+  accepted
+  declined
 }
 
 model TicketCategory {

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -48,6 +48,9 @@ import { LedgerController } from './ledger/ledger.controller';
 import { LedgerService } from './ledger/ledger.service';
 import { SublettingController } from './subletting/subletting.controller';
 import { SublettingService } from './subletting/subletting.service';
+import { TicketController } from './ticket/ticket.controller';
+import { TicketRepository } from './ticket/ticket.repository';
+import { TicketService } from './ticket/ticket.service';
 
 @Module({
   imports: [AuthModule, ScheduleModule.forRoot()],
@@ -66,6 +69,7 @@ import { SublettingService } from './subletting/subletting.service';
     PaymentController,
     LedgerController,
     SublettingController,
+    TicketController,
   ],
   providers: [
     AppService,
@@ -101,6 +105,8 @@ import { SublettingService } from './subletting/subletting.service';
     SquareProvider,
     LedgerService,
     SublettingService,
+    TicketRepository,
+    TicketService,
   ],
 })
 export class AppModule {}

--- a/apps/api/src/ticket/ticket.controller.ts
+++ b/apps/api/src/ticket/ticket.controller.ts
@@ -1,0 +1,51 @@
+import { Body, Controller, Get, Param, Patch, Post } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import { z } from 'zod';
+import { TicketService } from './ticket.service';
+
+const TicketCreate = z.object({
+  unitId: z.string(),
+  description: z.string(),
+  type: z.enum(['maintenance', 'support', 'other']),
+  priority: z.enum(['low', 'medium', 'high']),
+  categoryId: z.string().optional(),
+});
+
+const TicketUpdate = z.object({
+  status: z.enum(['open', 'in_progress', 'completed']).optional(),
+  assignedToId: z.string().optional(),
+  assignmentStatus: z.enum(['pending', 'accepted', 'declined']).optional(),
+  eta: z.coerce.date().optional(),
+  partsCost: z.number().optional(),
+  labourCost: z.number().optional(),
+  rating: z.number().int().min(1).max(5).optional(),
+  review: z.string().optional(),
+});
+
+@ApiTags('tickets')
+@Controller('tickets')
+export class TicketController {
+  constructor(private readonly service: TicketService) {}
+
+  @Get()
+  list() {
+    return this.service.list();
+  }
+
+  @Get(':id')
+  get(@Param('id') id: string) {
+    return this.service.get(id);
+  }
+
+  @Post()
+  create(@Body() body: any) {
+    const data = TicketCreate.parse(body);
+    return this.service.create(data);
+  }
+
+  @Patch(':id')
+  update(@Param('id') id: string, @Body() body: any) {
+    const data = TicketUpdate.parse(body);
+    return this.service.update(id, data);
+  }
+}

--- a/apps/api/src/ticket/ticket.repository.ts
+++ b/apps/api/src/ticket/ticket.repository.ts
@@ -1,0 +1,14 @@
+import { Inject, Injectable, Scope } from '@nestjs/common';
+import { REQUEST } from '@nestjs/core';
+import { Request } from 'express';
+import { PrismaService } from '../prisma.service';
+import { BaseRepository } from '../common/base.repository';
+
+/** Repository for Ticket model scoped by organization. */
+@Injectable({ scope: Scope.REQUEST })
+export class TicketRepository extends BaseRepository<any> {
+  constructor(prisma: PrismaService, @Inject(REQUEST) request: Request) {
+    super(prisma, request);
+    this.model = prisma.ticket;
+  }
+}

--- a/apps/api/src/ticket/ticket.service.ts
+++ b/apps/api/src/ticket/ticket.service.ts
@@ -1,0 +1,50 @@
+import { Inject, Injectable, Scope } from '@nestjs/common';
+import { REQUEST } from '@nestjs/core';
+import { Request } from 'express';
+import { TicketRepository } from './ticket.repository';
+import { PrismaService } from '../prisma.service';
+
+@Injectable({ scope: Scope.REQUEST })
+export class TicketService {
+  constructor(
+    private readonly repo: TicketRepository,
+    private readonly prisma: PrismaService,
+    @Inject(REQUEST) private readonly request: Request,
+  ) {}
+
+  list() {
+    return this.repo.findMany({ include: { category: true } });
+  }
+
+  get(id: string) {
+    return this.repo.findUnique(id, { include: { category: true } });
+  }
+
+  create(data: any) {
+    return this.repo.create(data);
+  }
+
+  async update(id: string, data: any) {
+    const before = await this.repo.findUnique(id);
+    const ticket = await this.repo.update(id, data);
+    if (data.status && before?.status !== data.status) {
+      await this.notifyTenants(before.unitId, `Ticket ${id} status updated to ${data.status}`);
+    }
+    return ticket;
+  }
+
+  private async notifyTenants(unitId: string, message: string) {
+    const orgId = (this.request as any).orgId;
+    const shares = await this.prisma.leaseShare.findMany({
+      where: { lease: { unitId, orgId, status: 'active' } },
+      include: { membership: true },
+    });
+    await Promise.all(
+      shares.map((s) =>
+        this.prisma.notification.create({
+          data: { orgId, userId: s.membership.userId, message },
+        }),
+      ),
+    );
+  }
+}

--- a/apps/web/app/tickets/page.tsx
+++ b/apps/web/app/tickets/page.tsx
@@ -55,6 +55,19 @@ export default async function TicketsPage() {
             >
               <p>{t.description}</p>
               <SlaBadge ticket={t} />
+              <p>Assigned: {t.assignedToId ? t.assignedToId : 'Unassigned'}</p>
+              {t.eta && <p>ETA: {new Date(t.eta).toLocaleString()}</p>}
+              {(t.partsCost || t.labourCost) && (
+                <p>
+                  Cost: £{(t.partsCost || 0) + (t.labourCost || 0)} (parts £{t.partsCost || 0}, labour £{t.labourCost || 0})
+                </p>
+              )}
+              {t.status === 'completed' && (
+                <p>
+                  {t.rating ? `Rating: ${t.rating}/5` : 'Awaiting review'}
+                  {t.review && <span> - {t.review}</span>}
+                </p>
+              )}
             </div>
           ))}
         </div>

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -71,6 +71,7 @@ export interface PaymentScheduleItem {
 export type TicketStatus = 'open' | 'in_progress' | 'completed';
 export type TicketPriority = 'low' | 'medium' | 'high';
 export type TicketType = 'maintenance' | 'support' | 'other';
+export type AssignmentStatus = 'pending' | 'accepted' | 'declined';
 
 export interface TicketCategory {
   id: string;
@@ -98,6 +99,13 @@ export interface Ticket {
   type: TicketType;
   priority: TicketPriority;
   status: TicketStatus;
+  assignedToId?: string;
+  assignmentStatus: AssignmentStatus;
+  eta?: Date;
+  partsCost: number;
+  labourCost: number;
+  rating?: number;
+  review?: string;
   categoryId?: string;
   category?: TicketCategory;
   notes: TicketNote[];


### PR DESCRIPTION
## Summary
- expand ticket schema with assignment, ETA, cost tracking, and review fields
- add ticket module with notification on status updates
- surface assignment, ETA, costs, and ratings in ticket UI

## Testing
- `npx prisma generate` *(fails: npm error canceled)*
- `npm run lint` *(fails: turbo not found)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b000ad7758832eafcbca93372c36fc