### PR TITLE
feat: process sensor events and show timeline

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -18,6 +18,7 @@
     "@nestjs/jwt": "^11.0.0",
     "@nestjs/passport": "^11.0.5",
     "@nestjs/schedule": "^2.2.0",
+    "@nestjs/bull": "^10.0.0",
     "@prisma/client": "^5.4.1",
     "@aws-sdk/client-s3": "^3.454.0",
     "@aws-sdk/s3-request-presigner": "^3.454.0",
@@ -30,7 +31,8 @@
     "zod": "^3.22.2",
     "handlebars": "^4.7.8",
     "pdfkit": "^0.13.0",
-    "docusign-esign": "^5.11.0"
+    "docusign-esign": "^5.11.0",
+    "bull": "^4.10.4"
   },
   "devDependencies": {
     "@types/passport-google-oauth20": "^2.0.11",

--- a/apps/api/prisma/migrations/20240701120000_add_sensor_events/migration.sql
+++ b/apps/api/prisma/migrations/20240701120000_add_sensor_events/migration.sql
@@ -1,0 +1,12 @@
+CREATE TABLE "SensorEvent" (
+  "id" TEXT NOT NULL PRIMARY KEY,
+  "orgId" TEXT NOT NULL,
+  "unitId" TEXT NOT NULL,
+  "type" TEXT NOT NULL,
+  "value" DOUBLE PRECISION,
+  "riskScore" INTEGER NOT NULL,
+  "action" TEXT NOT NULL,
+  "createdAt" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "SensorEvent_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Organization"("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+  CONSTRAINT "SensorEvent_unitId_fkey" FOREIGN KEY ("unitId") REFERENCES "Unit"("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -52,6 +52,7 @@ model Organization {
   SublettingApproval SublettingApproval[]
   AirbnbIntegration  AirbnbIntegration[]
   SublettingPayout   SublettingPayout[]
+  SensorEvent        SensorEvent[]
 }
 
 model User {
@@ -150,6 +151,7 @@ model Unit {
   visits              Visit[]
   devices             Device[]
   certificates        Certificate[]
+  sensorEvents        SensorEvent[]
   createdAt           DateTime         @default(now())
   imageUrl            String?
   virtualTourEmbedUrl String?
@@ -195,6 +197,19 @@ model Device {
   metadata   Json?
   createdAt  DateTime     @default(now())
   deletedAt  DateTime?
+}
+
+model SensorEvent {
+  id        String       @id @default(cuid())
+  org       Organization @relation(fields: [orgId], references: [id])
+  orgId     String
+  unit      Unit         @relation(fields: [unitId], references: [id])
+  unitId    String
+  type      String
+  value     Float?
+  riskScore Int
+  action    String
+  createdAt DateTime     @default(now())
 }
 
 model Household {
@@ -364,7 +379,7 @@ model Ticket {
   type        TicketType
   priority    TicketPriority
   status      TicketStatus   @default(open)
-  category    TicketCategory @relation(fields: [categoryId], references: [id])
+  category    TicketCategory? @relation(fields: [categoryId], references: [id])
   categoryId  String?
   assignedTo   Membership?    @relation("TicketAssignedTo", fields: [assignedToId], references: [id])
   assignedToId String?

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 import { ScheduleModule } from '@nestjs/schedule';
+import { BullModule } from '@nestjs/bull';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { PrismaService } from './prisma.service';
@@ -51,9 +52,22 @@ import { SublettingService } from './subletting/subletting.service';
 import { TicketController } from './ticket/ticket.controller';
 import { TicketRepository } from './ticket/ticket.repository';
 import { TicketService } from './ticket/ticket.service';
+import { SensorEventService } from './sensor/sensor-event.service';
+import { SensorEventController } from './sensor/sensor-event.controller';
+import { SensorEventProcessor } from './sensor/sensor-event.processor';
 
 @Module({
-  imports: [AuthModule, ScheduleModule.forRoot()],
+  imports: [
+    AuthModule,
+    ScheduleModule.forRoot(),
+    BullModule.forRoot({
+      redis: {
+        host: process.env.REDIS_HOST || 'localhost',
+        port: +(process.env.REDIS_PORT || 6379),
+      },
+    }),
+    BullModule.registerQueue({ name: 'sensor-events' }),
+  ],
   controllers: [
     AppController,
     PropertyController,
@@ -70,6 +84,7 @@ import { TicketService } from './ticket/ticket.service';
     LedgerController,
     SublettingController,
     TicketController,
+    SensorEventController,
   ],
   providers: [
     AppService,
@@ -107,6 +122,8 @@ import { TicketService } from './ticket/ticket.service';
     SublettingService,
     TicketRepository,
     TicketService,
+    SensorEventService,
+    SensorEventProcessor,
   ],
 })
 export class AppModule {}

--- a/apps/api/src/sensor/sensor-event.controller.ts
+++ b/apps/api/src/sensor/sensor-event.controller.ts
@@ -1,0 +1,25 @@
+import { Body, Controller, Get, Param, Post } from '@nestjs/common';
+import { SensorEventService } from './sensor-event.service';
+import { z } from 'zod';
+
+const EventSchema = z.object({
+  unitId: z.string(),
+  type: z.enum(['leak', 'temp']),
+  value: z.number().optional(),
+});
+
+@Controller()
+export class SensorEventController {
+  constructor(private readonly service: SensorEventService) {}
+
+  @Post('webhooks/sensor')
+  webhook(@Body() body: any) {
+    const data = EventSchema.parse(body);
+    return this.service.enqueue(data);
+  }
+
+  @Get('units/:id/events')
+  list(@Param('id') id: string) {
+    return this.service.list(id);
+  }
+}

--- a/apps/api/src/sensor/sensor-event.processor.ts
+++ b/apps/api/src/sensor/sensor-event.processor.ts
@@ -1,0 +1,59 @@
+import { Processor, Process } from '@nestjs/bull';
+import { Job } from 'bull';
+import { PrismaService } from '../prisma.service';
+import { TicketPriority, TicketType } from '@prisma/client';
+
+interface SensorEventJob {
+  unitId: string;
+  type: 'leak' | 'temp';
+  value?: number;
+}
+
+@Processor('sensor-events')
+export class SensorEventProcessor {
+  constructor(private readonly prisma: PrismaService) {}
+
+  @Process('ingest')
+  async handle(job: Job<SensorEventJob>) {
+    const { unitId, type, value } = job.data;
+    const unit = await this.prisma.unit.findUnique({ where: { id: unitId } });
+    if (!unit) return;
+
+    const { risk, action } = this.evaluate(type, value);
+
+    await this.prisma.sensorEvent.create({
+      data: {
+        orgId: unit.orgId,
+        unitId,
+        type,
+        value,
+        riskScore: risk,
+        action,
+      },
+    });
+
+    await this.prisma.ticket.create({
+      data: {
+        orgId: unit.orgId,
+        unitId,
+        description: `${type} event${value !== undefined ? ` value ${value}` : ''}. Recommended action: ${action}`,
+        type: TicketType.maintenance,
+        priority: risk > 70 ? TicketPriority.high : TicketPriority.medium,
+      },
+    });
+  }
+
+  private evaluate(type: 'leak' | 'temp', value?: number) {
+    if (type === 'leak') {
+      return { risk: 90, action: 'Dispatch plumber to investigate leak' };
+    }
+    const temp = value ?? 0;
+    if (temp > 30) {
+      return { risk: 70, action: 'Check HVAC for overheating' };
+    }
+    if (temp < 5) {
+      return { risk: 60, action: 'Check heating system for issues' };
+    }
+    return { risk: 10, action: 'Monitor temperature' };
+  }
+}

--- a/apps/api/src/sensor/sensor-event.service.ts
+++ b/apps/api/src/sensor/sensor-event.service.ts
@@ -1,0 +1,30 @@
+import { Injectable } from '@nestjs/common';
+import { InjectQueue } from '@nestjs/bull';
+import { Queue } from 'bull';
+import { PrismaService } from '../prisma.service';
+
+interface SensorEventJob {
+  unitId: string;
+  type: 'leak' | 'temp';
+  value?: number;
+}
+
+@Injectable()
+export class SensorEventService {
+  constructor(
+    @InjectQueue('sensor-events') private readonly queue: Queue,
+    private readonly prisma: PrismaService,
+  ) {}
+
+  async enqueue(data: SensorEventJob) {
+    await this.queue.add('ingest', data);
+    return { queued: true };
+  }
+
+  list(unitId: string) {
+    return this.prisma.sensorEvent.findMany({
+      where: { unitId },
+      orderBy: { createdAt: 'desc' },
+    });
+  }
+}

--- a/apps/web/app/units/[id]/UnitDetailClient.tsx
+++ b/apps/web/app/units/[id]/UnitDetailClient.tsx
@@ -8,11 +8,12 @@ interface Props {
 }
 
 export default function UnitDetailClient({ unit }: Props) {
-  const [tab, setTab] = useState<'details' | 'virtual'>('details');
+  const [tab, setTab] = useState<'details' | 'virtual' | 'events'>('details');
   const [embedUrl, setEmbedUrl] = useState(unit.virtualTourEmbedUrl || '');
   const [saving, setSaving] = useState(false);
   const [images, setImages] = useState<string[]>(unit.virtualTourImages || []);
   const [pricing, setPricing] = useState<any>(null);
+  const [events, setEvents] = useState<any[]>([]);
 
   useEffect(() => {
     fetch(
@@ -21,6 +22,13 @@ export default function UnitDetailClient({ unit }: Props) {
       .then((res) => res.json())
       .then((data) => setPricing(data));
   }, [unit.id]);
+
+  useEffect(() => {
+    if (tab !== 'events') return;
+    fetch(`${process.env.NEXT_PUBLIC_API_URL}/units/${unit.id}/events`)
+      .then((res) => res.json())
+      .then((data) => setEvents(data));
+  }, [tab, unit.id]);
 
   async function applySuggestion() {
     if (!pricing?.leaseId) return;
@@ -48,6 +56,7 @@ export default function UnitDetailClient({ unit }: Props) {
       <div className="flex gap-2">
         <button onClick={() => setTab('details')}>Details</button>
         <button onClick={() => setTab('virtual')}>Virtual Tour</button>
+        <button onClick={() => setTab('events')}>IoT Events</button>
       </div>
       {tab === 'details' && (
         <div>
@@ -93,6 +102,21 @@ export default function UnitDetailClient({ unit }: Props) {
               <img key={url} src={url} alt="virtual tour" className="h-48" />
             ))}
           </div>
+        </div>
+      )}
+      {tab === 'events' && (
+        <div className="mt-4 space-y-2">
+          {events.map((e) => (
+            <div key={e.id} className="border-b pb-2">
+              <div>
+                {new Date(e.createdAt).toLocaleString()} - {e.type}
+                {e.value !== null && e.value !== undefined && ` (${e.value})`} -
+                risk {e.riskScore}
+              </div>
+              <div className="text-sm text-gray-600">{e.action}</div>
+            </div>
+          ))}
+          {!events.length && <div>No events</div>}
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- queue incoming leak and temperature webhooks
- create sensor events and auto maintenance tickets with risk scores
- display unit IoT event timeline in the web app

## Testing
- `npx turbo lint` *(fails: turbo not found)*
- `npm test --prefix apps/api` *(fails: Cannot find module '@tenancy/types')*


------
https://chatgpt.com/codex/tasks/task_e_68b003724dac832e80220577a178a46e