### PR TITLE
feat(api): add tradesperson marketplace

### DIFF
--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -53,6 +53,7 @@ model Organization {
   AirbnbIntegration  AirbnbIntegration[]
   SublettingPayout   SublettingPayout[]
   SensorEvent        SensorEvent[]
+  ServiceJob        ServiceJob[]
 }
 
 model User {
@@ -592,4 +593,29 @@ model SublettingPayout {
   amount      Float
   platformFee Float
   createdAt   DateTime           @default(now())
+}
+
+model TradespersonProfile {
+  id           String        @id @default(cuid())
+  user         User          @relation(fields: [userId], references: [id])
+  userId       String        @unique
+  categories   String[]
+  coverageArea String
+  hourlyRate   Float
+  createdAt    DateTime      @default(now())
+  jobs         ServiceJob[]
+}
+
+model ServiceJob {
+  id             String              @id @default(cuid())
+  org            Organization        @relation(fields: [orgId], references: [id])
+  orgId          String
+  tradesperson   TradespersonProfile @relation(fields: [tradespersonId], references: [id])
+  tradespersonId String
+  description    String
+  price          Float
+  platformFee    Float
+  status         String              @default("pending")
+  createdAt      DateTime            @default(now())
+  completedAt    DateTime?
 }

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -55,6 +55,8 @@ import { TicketService } from './ticket/ticket.service';
 import { SensorEventService } from './sensor/sensor-event.service';
 import { SensorEventController } from './sensor/sensor-event.controller';
 import { SensorEventProcessor } from './sensor/sensor-event.processor';
+import { MarketplaceController } from './marketplace/marketplace.controller';
+import { MarketplaceService } from './marketplace/marketplace.service';
 
 @Module({
   imports: [
@@ -85,6 +87,7 @@ import { SensorEventProcessor } from './sensor/sensor-event.processor';
     SublettingController,
     TicketController,
     SensorEventController,
+    MarketplaceController,
   ],
   providers: [
     AppService,
@@ -124,6 +127,7 @@ import { SensorEventProcessor } from './sensor/sensor-event.processor';
     TicketService,
     SensorEventService,
     SensorEventProcessor,
+    MarketplaceService,
   ],
 })
 export class AppModule {}

--- a/apps/api/src/marketplace/marketplace.controller.ts
+++ b/apps/api/src/marketplace/marketplace.controller.ts
@@ -1,0 +1,30 @@
+import { Body, Controller, Get, Param, Post, Query } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import { MarketplaceService } from './marketplace.service';
+
+@ApiTags('marketplace')
+@Controller('marketplace')
+export class MarketplaceController {
+  constructor(private readonly service: MarketplaceService) {}
+
+  @Get('tradespeople')
+  list(
+    @Query('category') category?: string,
+    @Query('area') area?: string,
+  ) {
+    return this.service.listTradespeople(category, area);
+  }
+
+  @Post('jobs')
+  createJob(
+    @Body() body: { orgId: string; tradespersonId: string; description: string; price: number },
+  ) {
+    return this.service.createJob(body);
+  }
+
+  @Post('jobs/:id/checkout')
+  checkout(@Param('id') id: string) {
+    return this.service.checkout(id);
+  }
+}
+

--- a/apps/api/src/marketplace/marketplace.service.ts
+++ b/apps/api/src/marketplace/marketplace.service.ts
@@ -1,0 +1,79 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma.service';
+import { LedgerService } from '../ledger/ledger.service';
+
+@Injectable()
+export class MarketplaceService {
+  constructor(
+    private prisma: PrismaService,
+    private ledger: LedgerService,
+  ) {}
+
+  /**
+   * List tradespeople filtered by optional category or area.
+   */
+  listTradespeople(category?: string, area?: string) {
+    return this.prisma.tradespersonProfile.findMany({
+      where: {
+        ...(category ? { categories: { has: category } } : {}),
+        ...(area ? { coverageArea: { contains: area, mode: 'insensitive' } } : {}),
+      },
+    });
+  }
+
+  /**
+   * Create a service job invitation from landlord to tradesperson.
+   */
+  async createJob(data: {
+    orgId: string;
+    tradespersonId: string;
+    description: string;
+    price: number;
+  }) {
+    const platformFee = this.computeFee(data.price);
+    return this.prisma.serviceJob.create({
+      data: {
+        ...data,
+        platformFee,
+      },
+    });
+  }
+
+  /**
+   * Complete checkout for a job, recording ledger entries.
+   */
+  async checkout(jobId: string) {
+    const job = await this.prisma.serviceJob.findUnique({ where: { id: jobId } });
+    if (!job) throw new Error('Job not found');
+    if (job.status === 'completed') return job;
+
+    // Record payout to tradesperson
+    await this.ledger.create({
+      orgId: job.orgId,
+      description: `Payout for job ${job.id}`,
+      debitAccount: 'RepairsExpense',
+      creditAccount: 'Cash',
+      amount: job.price,
+    });
+
+    // Record platform fee
+    await this.ledger.create({
+      orgId: job.orgId,
+      description: `Platform fee for job ${job.id}`,
+      debitAccount: 'Cash',
+      creditAccount: 'PlatformRevenue',
+      amount: job.platformFee,
+    });
+
+    return this.prisma.serviceJob.update({
+      where: { id: jobId },
+      data: { status: 'completed', completedAt: new Date() },
+    });
+  }
+
+  private computeFee(price: number) {
+    const RATE = 0.1; // 10% platform fee
+    return Math.round(price * RATE * 100) / 100;
+  }
+}
+


### PR DESCRIPTION
## Summary
- add marketplace controller and service for hiring tradespeople
- extend Prisma schema with tradesperson profiles and service jobs
- register marketplace endpoints and integrate ledger entries

## Testing
- `npx prisma generate` *(fails: Need to install the following packages: prisma@6.15.0)*
- `npm test` *(fails: Cannot find module '@nestjs/common')*
- `npm run lint` *(fails: ESLint couldn't find configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68b006f35208832eb76f42471e13c2f7