### PR TITLE
feat: schedule visits with reminders

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -32,7 +32,10 @@
     "handlebars": "^4.7.8",
     "pdfkit": "^0.13.0",
     "docusign-esign": "^5.11.0",
-    "bull": "^4.10.4"
+    "bull": "^4.10.4",
+    "ics": "^2.41.0",
+    "nodemailer": "^6.9.8",
+    "twilio": "^4.11.0"
   },
   "devDependencies": {
     "@types/passport-google-oauth20": "^2.0.11",

--- a/apps/api/prisma/migrations/20240711120000_add_visit_outcome/migration.sql
+++ b/apps/api/prisma/migrations/20240711120000_add_visit_outcome/migration.sql
@@ -1,0 +1,10 @@
+-- Add visit type and outcome tracking
+CREATE TYPE "VisitType" AS ENUM ('inspection', 'engineer');
+
+CREATE TYPE "VisitOutcome" AS ENUM ('completed', 'no_show', 'follow_up_required');
+
+ALTER TABLE "Visit"
+  ADD COLUMN     "type" "VisitType" NOT NULL DEFAULT 'inspection',
+  ADD COLUMN     "outcome" "VisitOutcome",
+  ADD COLUMN     "followUpAt" TIMESTAMP(3);
+

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -461,8 +461,22 @@ model Visit {
   propertyId  String?
   scheduledAt DateTime
   notes       String?
+  type        VisitType
+  outcome     VisitOutcome?
+  followUpAt  DateTime?
   Unit        Unit?        @relation(fields: [unitId], references: [id])
   unitId      String?
+}
+
+enum VisitType {
+  inspection
+  engineer
+}
+
+enum VisitOutcome {
+  completed
+  no_show
+  follow_up_required
 }
 
 model UtilityReading {

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -57,6 +57,9 @@ import { SensorEventController } from './sensor/sensor-event.controller';
 import { SensorEventProcessor } from './sensor/sensor-event.processor';
 import { MarketplaceController } from './marketplace/marketplace.controller';
 import { MarketplaceService } from './marketplace/marketplace.service';
+import { VisitController } from './visit/visit.controller';
+import { VisitRepository } from './visit/visit.repository';
+import { VisitService } from './visit/visit.service';
 
 @Module({
   imports: [
@@ -86,6 +89,7 @@ import { MarketplaceService } from './marketplace/marketplace.service';
     LedgerController,
     SublettingController,
     TicketController,
+    VisitController,
     SensorEventController,
     MarketplaceController,
   ],
@@ -125,6 +129,8 @@ import { MarketplaceService } from './marketplace/marketplace.service';
     SublettingService,
     TicketRepository,
     TicketService,
+    VisitRepository,
+    VisitService,
     SensorEventService,
     SensorEventProcessor,
     MarketplaceService,

--- a/apps/api/src/visit/visit.controller.ts
+++ b/apps/api/src/visit/visit.controller.ts
@@ -1,0 +1,50 @@
+import { Body, Controller, Get, Param, Patch, Post } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import { z } from 'zod';
+import { VisitService } from './visit.service';
+
+const VisitCreate = z.object({
+  propertyId: z.string().optional(),
+  unitId: z.string().optional(),
+  ticketId: z.string().optional(),
+  scheduledAt: z.coerce.date(),
+  type: z.enum(['inspection', 'engineer']),
+  notes: z.string().optional(),
+  attendeeEmail: z.string().email().optional(),
+  attendeePhone: z.string().optional(),
+});
+
+const VisitUpdate = z.object({
+  outcome: z.enum(['completed', 'no_show', 'follow_up_required']).optional(),
+  followUpAt: z.coerce.date().optional(),
+  notes: z.string().optional(),
+});
+
+@ApiTags('visits')
+@Controller('visits')
+export class VisitController {
+  constructor(private readonly service: VisitService) {}
+
+  @Get()
+  list() {
+    return this.service.list();
+  }
+
+  @Get(':id')
+  get(@Param('id') id: string) {
+    return this.service.get(id);
+  }
+
+  @Post()
+  create(@Body() body: any) {
+    const data = VisitCreate.parse(body);
+    return this.service.create(data);
+  }
+
+  @Patch(':id')
+  update(@Param('id') id: string, @Body() body: any) {
+    const data = VisitUpdate.parse(body);
+    return this.service.update(id, data);
+  }
+}
+

--- a/apps/api/src/visit/visit.repository.ts
+++ b/apps/api/src/visit/visit.repository.ts
@@ -1,0 +1,15 @@
+import { Inject, Injectable, Scope } from '@nestjs/common';
+import { REQUEST } from '@nestjs/core';
+import { Request } from 'express';
+import { PrismaService } from '../prisma.service';
+import { BaseRepository } from '../common/base.repository';
+
+/** Repository for Visit model scoped by organization. */
+@Injectable({ scope: Scope.REQUEST })
+export class VisitRepository extends BaseRepository<any> {
+  constructor(prisma: PrismaService, @Inject(REQUEST) request: Request) {
+    super(prisma, request);
+    this.model = prisma.visit;
+  }
+}
+

--- a/apps/api/src/visit/visit.service.ts
+++ b/apps/api/src/visit/visit.service.ts
@@ -1,0 +1,102 @@
+import { Inject, Injectable, Scope } from '@nestjs/common';
+import { REQUEST } from '@nestjs/core';
+import { Request } from 'express';
+import nodemailer from 'nodemailer';
+import twilio from 'twilio';
+import { createEvent } from 'ics';
+import { VisitRepository } from './visit.repository';
+
+@Injectable({ scope: Scope.REQUEST })
+export class VisitService {
+  constructor(
+    private readonly repo: VisitRepository,
+    @Inject(REQUEST) private readonly request: Request,
+  ) {}
+
+  list() {
+    return this.repo.findMany();
+  }
+
+  get(id: string) {
+    return this.repo.findUnique(id);
+  }
+
+  async create(data: any) {
+    const { attendeeEmail, attendeePhone, ...rest } = data;
+    const visit = await this.repo.create(rest);
+    await this.sendNotifications(visit, attendeeEmail, attendeePhone);
+    return visit;
+  }
+
+  update(id: string, data: any) {
+    return this.repo.update(id, data);
+  }
+
+  private async sendNotifications(
+    visit: any,
+    email?: string,
+    phone?: string,
+  ) {
+    if (email) {
+      await this.sendEmail(email, visit);
+    }
+    if (phone) {
+      await this.sendSmsWhatsApp(phone, visit);
+    }
+  }
+
+  private async sendEmail(email: string, visit: any) {
+    const { SMTP_HOST, SMTP_PORT, SMTP_USER, SMTP_PASS } = process.env;
+    if (!SMTP_HOST) return;
+    const transporter = nodemailer.createTransport({
+      host: SMTP_HOST,
+      port: +(SMTP_PORT || 587),
+      auth: SMTP_USER ? { user: SMTP_USER, pass: SMTP_PASS } : undefined,
+    });
+    const start: [number, number, number, number, number] = [
+      visit.scheduledAt.getUTCFullYear(),
+      visit.scheduledAt.getUTCMonth() + 1,
+      visit.scheduledAt.getUTCDate(),
+      visit.scheduledAt.getUTCHours(),
+      visit.scheduledAt.getUTCMinutes(),
+    ];
+    const { value } = createEvent({
+      title: `Visit (${visit.type})`,
+      start,
+      duration: { hours: 1 },
+    });
+    await transporter.sendMail({
+      to: email,
+      subject: 'Visit scheduled',
+      text: `Visit scheduled at ${visit.scheduledAt.toISOString()}`,
+      icalEvent: { filename: 'visit.ics', method: 'REQUEST', content: value },
+    });
+  }
+
+  private async sendSmsWhatsApp(phone: string, visit: any) {
+    const {
+      TWILIO_ACCOUNT_SID,
+      TWILIO_AUTH_TOKEN,
+      TWILIO_FROM_SMS,
+      TWILIO_FROM_WHATSAPP,
+    } = process.env;
+    if (!TWILIO_ACCOUNT_SID || !TWILIO_AUTH_TOKEN) return;
+    const client = twilio(TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN);
+    const body = `Visit (${visit.type}) scheduled at ${visit.scheduledAt.toISOString()}`;
+    if (TWILIO_FROM_SMS) {
+      await client.messages
+        .create({ from: TWILIO_FROM_SMS, to: phone, body })
+        .catch(() => null);
+    }
+    if (TWILIO_FROM_WHATSAPP) {
+      await client.messages
+        .create({
+          from: `whatsapp:${TWILIO_FROM_WHATSAPP}`,
+          to: `whatsapp:${phone}`,
+          body,
+        })
+        .catch(() => null);
+    }
+  }
+}
+

--- a/apps/web/app/visits/page.tsx
+++ b/apps/web/app/visits/page.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Calendar from 'react-calendar';
+import 'react-calendar/dist/Calendar.css';
+
+interface Visit {
+  id: string;
+  scheduledAt: string;
+  type: string;
+}
+
+export default function VisitsPage() {
+  const [date, setDate] = useState<Date>(new Date());
+  const [visits, setVisits] = useState<Visit[]>([]);
+
+  useEffect(() => {
+    fetch('/api/visits')
+      .then((r) => r.json())
+      .then(setVisits)
+      .catch(() => {});
+  }, []);
+
+  const dayVisits = visits.filter(
+    (v) => new Date(v.scheduledAt).toDateString() === date.toDateString(),
+  );
+
+  return (
+    <div className="p-4 space-y-4">
+      <Calendar onChange={(d) => setDate(d as Date)} value={date} />
+      <div>
+        <h2 className="font-bold">
+          Visits on {date.toDateString()}
+        </h2>
+        <ul className="list-disc pl-4">
+          {dayVisits.map((v) => (
+            <li key={v.id}>
+              {v.type} at {new Date(v.scheduledAt).toLocaleTimeString()}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}
+

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -25,7 +25,8 @@
     "@prisma/client": "^5.4.1",
     "bcryptjs": "^2.4.3",
     "speakeasy": "^2.0.0",
-    "qrcode": "^1.5.3"
+    "qrcode": "^1.5.3",
+    "react-calendar": "^4.0.0"
   },
   "devDependencies": {
     "typescript": "^5.3.0",


### PR DESCRIPTION
## Summary
- extend Visit schema with type, outcome, and follow-up fields
- add Visit API endpoints with calendar invites and Twilio notifications
- expose web calendar to display scheduled visits

## Testing
- `npm run lint` *(fails: turbo not found)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b00e26593c832ea4f895ae588f759d