### PR TITLE
feat: add webrtc call rooms with snapshot

### DIFF
--- a/apps/api/src/ticket/ticket.controller.ts
+++ b/apps/api/src/ticket/ticket.controller.ts
@@ -48,4 +48,10 @@ export class TicketController {
     const data = TicketUpdate.parse(body);
     return this.service.update(id, data);
   }
+
+  @Post(':id/snapshot')
+  addSnapshot(@Param('id') id: string, @Body() body: any) {
+    const data = z.object({ image: z.string() }).parse(body);
+    return this.service.addSnapshot(id, data.image);
+  }
 }

--- a/apps/api/src/ticket/ticket.service.ts
+++ b/apps/api/src/ticket/ticket.service.ts
@@ -50,6 +50,13 @@ export class TicketService {
     return ticket;
   }
 
+  addSnapshot(id: string, image: string) {
+    const orgId = (this.request as any).orgId;
+    return this.prisma.document.create({
+      data: { orgId, ticketId: id, url: image },
+    });
+  }
+
   private async notifyTenants(unitId: string, message: string) {
     const orgId = (this.request as any).orgId;
     const shares = await this.prisma.leaseShare.findMany({

--- a/apps/api/src/visit/visit.controller.ts
+++ b/apps/api/src/visit/visit.controller.ts
@@ -46,5 +46,11 @@ export class VisitController {
     const data = VisitUpdate.parse(body);
     return this.service.update(id, data);
   }
+
+  @Post(':id/snapshot')
+  addSnapshot(@Param('id') id: string, @Body() body: any) {
+    const data = z.object({ image: z.string() }).parse(body);
+    return this.service.addSnapshot(id, data.image);
+  }
 }
 

--- a/apps/api/src/visit/visit.service.ts
+++ b/apps/api/src/visit/visit.service.ts
@@ -5,11 +5,13 @@ import nodemailer from 'nodemailer';
 import twilio from 'twilio';
 import { createEvent } from 'ics';
 import { VisitRepository } from './visit.repository';
+import { PrismaService } from '../prisma.service';
 
 @Injectable({ scope: Scope.REQUEST })
 export class VisitService {
   constructor(
     private readonly repo: VisitRepository,
+    private readonly prisma: PrismaService,
     @Inject(REQUEST) private readonly request: Request,
   ) {}
 
@@ -30,6 +32,14 @@ export class VisitService {
 
   update(id: string, data: any) {
     return this.repo.update(id, data);
+  }
+
+  async addSnapshot(id: string, image: string) {
+    const orgId = (this.request as any).orgId;
+    const visit = await this.repo.findUnique(id);
+    return this.prisma.document.create({
+      data: { orgId, ticketId: visit?.ticketId || undefined, url: image },
+    });
   }
 
   private async sendNotifications(

--- a/apps/web/app/tickets/[id]/call/page.tsx
+++ b/apps/web/app/tickets/[id]/call/page.tsx
@@ -1,0 +1,10 @@
+import { CallRoom } from '@/components/CallRoom';
+
+export default function TicketCallPage({ params }: { params: { id: string } }) {
+  return (
+    <div className="p-4">
+      <CallRoom roomId={params.id} snapshotEndpoint={`/tickets/${params.id}/snapshot`} />
+    </div>
+  );
+}
+

--- a/apps/web/app/tickets/page.tsx
+++ b/apps/web/app/tickets/page.tsx
@@ -68,6 +68,12 @@ export default async function TicketsPage() {
                   {t.review && <span> - {t.review}</span>}
                 </p>
               )}
+              <a
+                href={`/tickets/${t.id}/call`}
+                className="text-blue-600 underline text-sm"
+              >
+                Call Room
+              </a>
             </div>
           ))}
         </div>

--- a/apps/web/app/visits/[id]/call/page.tsx
+++ b/apps/web/app/visits/[id]/call/page.tsx
@@ -1,0 +1,10 @@
+import { CallRoom } from '@/components/CallRoom';
+
+export default function VisitCallPage({ params }: { params: { id: string } }) {
+  return (
+    <div className="p-4">
+      <CallRoom roomId={params.id} snapshotEndpoint={`/visits/${params.id}/snapshot`} />
+    </div>
+  );
+}
+

--- a/apps/web/app/visits/page.tsx
+++ b/apps/web/app/visits/page.tsx
@@ -35,7 +35,13 @@ export default function VisitsPage() {
         <ul className="list-disc pl-4">
           {dayVisits.map((v) => (
             <li key={v.id}>
-              {v.type} at {new Date(v.scheduledAt).toLocaleTimeString()}
+              {v.type} at {new Date(v.scheduledAt).toLocaleTimeString()} -
+              <a
+                href={`/visits/${v.id}/call`}
+                className="text-blue-600 underline ml-1"
+              >
+                Call
+              </a>
             </li>
           ))}
         </ul>

--- a/apps/web/components/CallRoom.tsx
+++ b/apps/web/components/CallRoom.tsx
@@ -1,0 +1,136 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import Peer from 'peerjs';
+
+interface CallRoomProps {
+  roomId: string;
+  snapshotEndpoint: string;
+}
+
+export function CallRoom({ roomId, snapshotEndpoint }: CallRoomProps) {
+  const [peerId, setPeerId] = useState<string>();
+  const [remoteId, setRemoteId] = useState('');
+  const [networkWarning, setNetworkWarning] = useState(false);
+  const localVideo = useRef<HTMLVideoElement>(null);
+  const remoteVideo = useRef<HTMLVideoElement>(null);
+  const peerRef = useRef<Peer>();
+
+  useEffect(() => {
+    const connection = (navigator as any).connection;
+    const handleConnectionChange = () => {
+      if (connection && ['slow-2g', '2g'].includes(connection.effectiveType)) {
+        setNetworkWarning(true);
+      } else {
+        setNetworkWarning(false);
+      }
+    };
+    handleConnectionChange();
+    connection?.addEventListener('change', handleConnectionChange);
+
+    const peer = new Peer(undefined, { host: '0.peerjs.com', port: 443, secure: true });
+    peerRef.current = peer;
+    peer.on('open', (id) => setPeerId(id));
+    peer.on('call', (call) => {
+      navigator.mediaDevices
+        .getUserMedia(getConstraints())
+        .then((stream) => {
+          if (localVideo.current) {
+            localVideo.current.srcObject = stream;
+            localVideo.current.play().catch(() => {});
+          }
+          call.answer(stream);
+          call.on('stream', (remote) => {
+            if (remoteVideo.current) {
+              remoteVideo.current.srcObject = remote;
+              remoteVideo.current.play().catch(() => {});
+            }
+          });
+        })
+        .catch(() => {});
+    });
+    return () => {
+      connection?.removeEventListener('change', handleConnectionChange);
+      peer.destroy();
+    };
+  }, [roomId]);
+
+  function getConstraints() {
+    const connection = (navigator as any).connection;
+    if (connection && (connection.saveData || ['slow-2g', '2g'].includes(connection.effectiveType))) {
+      return { video: false, audio: true };
+    }
+    return { video: true, audio: true };
+  }
+
+  function startCall() {
+    navigator.mediaDevices
+      .getUserMedia(getConstraints())
+      .then((stream) => {
+        if (localVideo.current) {
+          localVideo.current.srcObject = stream;
+          localVideo.current.play().catch(() => {});
+        }
+        const call = peerRef.current?.call(remoteId, stream);
+        call?.on('stream', (remote) => {
+          if (remoteVideo.current) {
+            remoteVideo.current.srcObject = remote;
+            remoteVideo.current.play().catch(() => {});
+          }
+        });
+      })
+      .catch(() => {});
+  }
+
+  async function captureSnapshot() {
+    const video = remoteVideo.current || localVideo.current;
+    if (!video) return;
+    const canvas = document.createElement('canvas');
+    canvas.width = video.videoWidth;
+    canvas.height = video.videoHeight;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
+    const image = canvas.toDataURL('image/png');
+    const apiBase = process.env.NEXT_PUBLIC_API_URL || '';
+    await fetch(`${apiBase}${snapshotEndpoint}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ image }),
+    }).catch(() => {});
+  }
+
+  return (
+    <div className="space-y-2">
+      <div className="flex space-x-2">
+        <video ref={localVideo} muted className="w-1/2 bg-black" />
+        <video ref={remoteVideo} className="w-1/2 bg-black" />
+      </div>
+      {networkWarning && (
+        <p className="text-yellow-600">Network is weak - using audio only.</p>
+      )}
+      <div className="flex space-x-2 items-center">
+        <span className="text-sm">Your ID: {peerId}</span>
+        <input
+          className="border px-2 py-1 text-sm"
+          value={remoteId}
+          onChange={(e) => setRemoteId(e.target.value)}
+          placeholder="Remote ID"
+        />
+        <button
+          onClick={startCall}
+          className="bg-blue-500 text-white px-3 py-1 rounded"
+        >
+          Call
+        </button>
+        <button
+          onClick={captureSnapshot}
+          className="bg-green-600 text-white px-3 py-1 rounded"
+        >
+          Capture Snapshot
+        </button>
+      </div>
+    </div>
+  );
+}
+

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -27,7 +27,8 @@
     "speakeasy": "^2.0.0",
     "qrcode": "^1.5.3",
     "react-calendar": "^4.0.0",
-    "jspdf": "^2.5.1"
+    "jspdf": "^2.5.1",
+    "peerjs": "^1.5.2"
   },
   "devDependencies": {
     "typescript": "^5.3.0",

--- a/apps/web/types/peerjs.d.ts
+++ b/apps/web/types/peerjs.d.ts
@@ -1,0 +1,1 @@
+declare module 'peerjs';


### PR DESCRIPTION
## Summary
- add CallRoom component for peer-to-peer WebRTC calls with network fallback and snapshot capture
- expose call pages for tickets and visits
- store captured snapshots through new ticket/visit snapshot endpoints

## Testing
- `npm run lint` *(fails: turbo not found)*
- `npm run typecheck` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b023d09c34832e98520a6291456c5b