### PR TITLE
feat: add assessment wizard with anomaly review

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -60,6 +60,8 @@ import { MarketplaceService } from './marketplace/marketplace.service';
 import { VisitController } from './visit/visit.controller';
 import { VisitRepository } from './visit/visit.repository';
 import { VisitService } from './visit/visit.service';
+import { AssessmentController } from './assessment/assessment.controller';
+import { AssessmentService } from './assessment/assessment.service';
 
 @Module({
   imports: [
@@ -92,6 +94,7 @@ import { VisitService } from './visit/visit.service';
     VisitController,
     SensorEventController,
     MarketplaceController,
+    AssessmentController,
   ],
   providers: [
     AppService,
@@ -134,6 +137,7 @@ import { VisitService } from './visit/visit.service';
     SensorEventService,
     SensorEventProcessor,
     MarketplaceService,
+    AssessmentService,
   ],
 })
 export class AppModule {}

--- a/apps/api/src/assessment/assessment.controller.ts
+++ b/apps/api/src/assessment/assessment.controller.ts
@@ -1,0 +1,26 @@
+import { Body, Controller, Post } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import { z } from 'zod';
+import { AssessmentService } from './assessment.service';
+
+const ItemSchema = z.object({
+  status: z.enum(['pass', 'fail']),
+  photo: z.string().optional(),
+});
+
+const AssessmentCreate = z.object({
+  templateId: z.string(),
+  items: z.record(ItemSchema),
+});
+
+@ApiTags('assessments')
+@Controller('assessments')
+export class AssessmentController {
+  constructor(private readonly service: AssessmentService) {}
+
+  @Post()
+  create(@Body() body: any) {
+    const data = AssessmentCreate.parse(body);
+    return this.service.create(data);
+  }
+}

--- a/apps/api/src/assessment/assessment.service.ts
+++ b/apps/api/src/assessment/assessment.service.ts
@@ -1,0 +1,32 @@
+import { Injectable } from '@nestjs/common';
+
+interface AssessmentItem {
+  id: string;
+  status: 'pass' | 'fail';
+  photo?: string;
+}
+
+interface AssessmentData {
+  templateId: string;
+  items: Record<string, AssessmentItem>;
+}
+
+let counter = 1;
+
+@Injectable()
+export class AssessmentService {
+  private assessments: any[] = [];
+
+  create(data: AssessmentData) {
+    const needsReview = Object.values(data.items).some(
+      (item) => item.status === 'fail' || !item.photo,
+    );
+    const assessment = {
+      id: String(counter++),
+      ...data,
+      needsReview,
+    };
+    this.assessments.push(assessment);
+    return { id: assessment.id, needsReview };
+  }
+}

--- a/apps/web/app/api/assessments/route.ts
+++ b/apps/web/app/api/assessments/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from 'next/server';
+
+export async function POST(req: Request) {
+  const body = await req.json();
+  const res = await fetch(
+    process.env.API_URL || 'http://localhost:3001/assessments',
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    },
+  );
+  const data = await res.json();
+  return NextResponse.json(data);
+}

--- a/apps/web/app/assessments/page.tsx
+++ b/apps/web/app/assessments/page.tsx
@@ -1,0 +1,116 @@
+'use client';
+
+import { useState } from 'react';
+import {
+  assessmentTemplates,
+  getTemplate,
+  AssessmentTemplate,
+} from '../../lib/assessmentTemplates';
+
+type ItemResult = {
+  status?: 'pass' | 'fail';
+  photo?: string;
+};
+
+export default function AssessmentPage() {
+  const [templateId, setTemplateId] = useState('minor-damage');
+  const template: AssessmentTemplate | undefined = getTemplate(templateId);
+  const [results, setResults] = useState<Record<string, ItemResult>>({});
+  const [submitted, setSubmitted] = useState(false);
+  const [needsReview, setNeedsReview] = useState(false);
+
+  const updateStatus = (itemId: string, status: 'pass' | 'fail') => {
+    setResults((prev) => ({ ...prev, [itemId]: { ...prev[itemId], status } }));
+  };
+
+  const handlePhoto = (itemId: string, file: File | null) => {
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      setResults((prev) => ({
+        ...prev,
+        [itemId]: { ...prev[itemId], photo: e.target?.result as string },
+      }));
+    };
+    reader.readAsDataURL(file);
+  };
+
+  const submit = async () => {
+    const res = await fetch('/api/assessments', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ templateId, items: results }),
+    });
+    const data = await res.json();
+    setNeedsReview(data.needsReview);
+    setSubmitted(true);
+  };
+
+  if (submitted) {
+    return (
+      <div className="p-4">
+        {needsReview ? (
+          <p>Assessment submitted. Anomalies detected for manual review.</p>
+        ) : (
+          <p>Assessment submitted successfully.</p>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-4 max-w-xl mx-auto">
+      <h1 className="text-2xl font-bold mb-4">Minor Assessment</h1>
+      <div className="mb-4">
+        <label className="block mb-1 font-medium">Template</label>
+        <select
+          className="border p-2 w-full"
+          value={templateId}
+          onChange={(e) => setTemplateId(e.target.value)}
+        >
+          {assessmentTemplates.map((t) => (
+            <option key={t.id} value={t.id}>
+              {t.name}
+            </option>
+          ))}
+        </select>
+      </div>
+      {template?.items.map((item) => (
+        <div key={item.id} className="mb-6">
+          <p className="font-medium mb-2">{item.description}</p>
+          <div className="flex items-center space-x-4 mb-2">
+            <label className="flex items-center space-x-1">
+              <input
+                type="radio"
+                name={`${item.id}-status`}
+                value="pass"
+                onChange={() => updateStatus(item.id, 'pass')}
+              />
+              <span>Pass</span>
+            </label>
+            <label className="flex items-center space-x-1">
+              <input
+                type="radio"
+                name={`${item.id}-status`}
+                value="fail"
+                onChange={() => updateStatus(item.id, 'fail')}
+              />
+              <span>Fail</span>
+            </label>
+          </div>
+          <input
+            type="file"
+            accept="image/*"
+            onChange={(e) => handlePhoto(item.id, e.target.files?.[0] ?? null)}
+          />
+        </div>
+      ))}
+      <button
+        className="bg-blue-600 text-white px-4 py-2 rounded"
+        onClick={submit}
+      >
+        Submit Assessment
+      </button>
+    </div>
+  );
+}

--- a/apps/web/lib/assessmentTemplates.ts
+++ b/apps/web/lib/assessmentTemplates.ts
@@ -1,0 +1,35 @@
+export type AssessmentItem = {
+  id: string;
+  description: string;
+};
+
+export type AssessmentTemplate = {
+  id: string;
+  name: string;
+  items: AssessmentItem[];
+};
+
+export const assessmentTemplates: AssessmentTemplate[] = [
+  {
+    id: 'minor-damage',
+    name: 'Minor Damage',
+    items: [
+      { id: 'walls', description: 'Check walls for cracks or marks' },
+      { id: 'fixtures', description: 'Inspect fixtures for damage' },
+      { id: 'appliances', description: 'Ensure appliances are functional' },
+    ],
+  },
+  {
+    id: 'cleanliness',
+    name: 'Cleanliness',
+    items: [
+      { id: 'kitchen', description: 'Kitchen surfaces are clean' },
+      { id: 'bathroom', description: 'Bathroom is sanitized' },
+      { id: 'flooring', description: 'Floors are free of debris' },
+    ],
+  },
+];
+
+export function getTemplate(id: string): AssessmentTemplate | undefined {
+  return assessmentTemplates.find((t) => t.id === id);
+}


### PR DESCRIPTION
## Summary
- add frontend wizard for minor tenant assessments with photo uploads
- proxy assessment submissions to backend API
- implement backend assessment endpoint with anomaly flagging

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx --yes turbo lint` *(fails: Could not resolve workspaces, missing `packageManager` field)*

------
https://chatgpt.com/codex/tasks/task_e_68b030633ae0832eb6f2cd794925c6eb