### PR TITLE
feat: add smart meter polling with mock connector

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -65,6 +65,12 @@ import { AssessmentService } from './assessment/assessment.service';
 import { UtilityReadingController } from './utility/utility-reading.controller';
 import { UtilityReadingRepository } from './utility/utility-reading.repository';
 import { UtilityReadingService } from './utility/utility-reading.service';
+import { SmartMeterAdapter } from './utility/smart-meter.adapter';
+import {
+  SMART_METER_CONNECTOR,
+  MockSmartMeterConnector,
+} from './utility/smart-meter.connector';
+import { SmartMeterPollingService } from './utility/smart-meter.polling.service';
 
 @Module({
   imports: [
@@ -144,6 +150,12 @@ import { UtilityReadingService } from './utility/utility-reading.service';
     AssessmentService,
     UtilityReadingRepository,
     UtilityReadingService,
+    SmartMeterAdapter,
+    SmartMeterPollingService,
+    {
+      provide: SMART_METER_CONNECTOR,
+      useClass: MockSmartMeterConnector,
+    },
   ],
 })
 export class AppModule {}

--- a/apps/api/src/utility/smart-meter.adapter.ts
+++ b/apps/api/src/utility/smart-meter.adapter.ts
@@ -1,0 +1,28 @@
+import { Inject, Injectable } from '@nestjs/common';
+import {
+  SMART_METER_CONNECTOR,
+  SmartMeterConnector,
+} from './smart-meter.connector';
+
+export interface MeterReading {
+  unitId: string;
+  reading: number;
+  recordedAt: Date;
+}
+
+/**
+ * Adapter layer wrapping the low level connector and
+ * returning a normalized reading structure.
+ */
+@Injectable()
+export class SmartMeterAdapter {
+  constructor(
+    @Inject(SMART_METER_CONNECTOR)
+    private readonly connector: SmartMeterConnector,
+  ) {}
+
+  async read(unitId: string): Promise<MeterReading> {
+    const reading = await this.connector.getReading(unitId);
+    return { unitId, reading, recordedAt: new Date() };
+  }
+}

--- a/apps/api/src/utility/smart-meter.connector.ts
+++ b/apps/api/src/utility/smart-meter.connector.ts
@@ -1,0 +1,20 @@
+export interface SmartMeterConnector {
+  /**
+   * Retrieve the latest usage reading for a given unit
+   * @param unitId Identifier of the unit being metered
+   */
+  getReading(unitId: string): Promise<number>;
+}
+
+export const SMART_METER_CONNECTOR = 'SMART_METER_CONNECTOR';
+
+/**
+ * Mock connector used for development and tests. Generates
+ * pseudo-random readings to emulate a physical smart meter.
+ */
+export class MockSmartMeterConnector implements SmartMeterConnector {
+  async getReading(): Promise<number> {
+    // return value between 0 and 999
+    return Math.floor(Math.random() * 1000);
+  }
+}

--- a/apps/api/src/utility/smart-meter.polling.service.ts
+++ b/apps/api/src/utility/smart-meter.polling.service.ts
@@ -1,0 +1,61 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Interval } from '@nestjs/schedule';
+import { SmartMeterAdapter, MeterReading } from './smart-meter.adapter';
+
+interface UsagePoint {
+  timestamp: Date;
+  reading: number;
+}
+
+/**
+ * Periodically polls the configured smart meter connector to collect
+ * readings for usage graphs and raises alerts when spikes are detected.
+ */
+@Injectable()
+export class SmartMeterPollingService {
+  private readonly logger = new Logger(SmartMeterPollingService.name);
+  private readonly history: Record<string, UsagePoint[]> = {};
+  private readonly lastReading: Record<string, number> = {};
+
+  constructor(private readonly adapter: SmartMeterAdapter) {}
+
+  @Interval(60000)
+  async poll() {
+    // In a real scenario the service would iterate over many units.
+    const unitId = 'demo-unit';
+    const reading: MeterReading = await this.adapter.read(unitId);
+    this.store(reading);
+    this.detectSpike(reading);
+  }
+
+  private store(reading: MeterReading) {
+    if (!this.history[reading.unitId]) {
+      this.history[reading.unitId] = [];
+    }
+    this.history[reading.unitId].push({
+      timestamp: reading.recordedAt,
+      reading: reading.reading,
+    });
+    // limit in-memory history for demo purposes
+    if (this.history[reading.unitId].length > 100) {
+      this.history[reading.unitId].shift();
+    }
+  }
+
+  private detectSpike(reading: MeterReading) {
+    const last = this.lastReading[reading.unitId];
+    if (last !== undefined && reading.reading - last > 100) {
+      this.logger.warn(
+        `Usage spike detected for ${reading.unitId}: ${reading.reading - last}`,
+      );
+    }
+    this.lastReading[reading.unitId] = reading.reading;
+  }
+
+  /**
+   * Retrieve usage data points for rendering graphs in the UI.
+   */
+  getUsageGraph(unitId: string): UsagePoint[] {
+    return this.history[unitId] || [];
+  }
+}


### PR DESCRIPTION
## Summary
- introduce smart meter connector interface with mock implementation
- adapter and scheduled polling service to collect usage data and alert on spikes
- register polling components in NestJS application module

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_e_68b37434afbc832e9da607da67dea400