### PR TITLE
feat: add utility provider comparison and referral tracking

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -73,6 +73,8 @@ import {
 import { SmartMeterPollingService } from './utility/smart-meter.polling.service';
 import { GreenScoreRepository } from './green/green-score.repository';
 import { GreenService } from './green/green.service';
+import { UtilityProviderController } from './utility-provider/utility-provider.controller';
+import { UtilityProviderService } from './utility-provider/utility-provider.service';
 
 @Module({
   imports: [
@@ -107,6 +109,7 @@ import { GreenService } from './green/green.service';
     MarketplaceController,
     AssessmentController,
     UtilityReadingController,
+    UtilityProviderController,
   ],
   providers: [
     AppService,
@@ -156,6 +159,7 @@ import { GreenService } from './green/green.service';
     SmartMeterPollingService,
     GreenScoreRepository,
     GreenService,
+    UtilityProviderService,
     {
       provide: SMART_METER_CONNECTOR,
       useClass: MockSmartMeterConnector,

--- a/apps/api/src/utility-provider/utility-provider.controller.ts
+++ b/apps/api/src/utility-provider/utility-provider.controller.ts
@@ -1,0 +1,23 @@
+import { Controller, Get, Post, Body } from '@nestjs/common';
+import { UtilityProviderService } from './utility-provider.service';
+
+@Controller('utility-providers')
+export class UtilityProviderController {
+  constructor(private readonly service: UtilityProviderService) {}
+
+  @Get()
+  list() {
+    return this.service.listProviders();
+  }
+
+  @Post('switch')
+  switch(@Body('providerId') providerId: string) {
+    this.service.switchProvider(providerId);
+    return { success: true };
+  }
+
+  @Get('referrals')
+  referrals() {
+    return this.service.getReferralCommissions();
+  }
+}

--- a/apps/api/src/utility-provider/utility-provider.service.ts
+++ b/apps/api/src/utility-provider/utility-provider.service.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@nestjs/common';
+import { UtilityProvider, ReferralCommission } from '@tenancy/types';
+
+@Injectable()
+export class UtilityProviderService {
+  private providers: UtilityProvider[] = [
+    { id: '1', name: 'PowerCo', rate: 0.15, estimatedSavings: 100 },
+    { id: '2', name: 'EnergyHub', rate: 0.13, estimatedSavings: 150 },
+    { id: '3', name: 'GreenEnergy', rate: 0.17, estimatedSavings: 80 },
+  ];
+
+  private commissions: Record<string, number> = {};
+
+  listProviders(): UtilityProvider[] {
+    return this.providers;
+  }
+
+  switchProvider(providerId: string): void {
+    this.commissions[providerId] = (this.commissions[providerId] || 0) + 50;
+  }
+
+  getReferralCommissions(): ReferralCommission[] {
+    return Object.entries(this.commissions).map(([providerId, amount]) => ({
+      providerId,
+      amount,
+    }));
+  }
+}

--- a/apps/web/app/utility-providers/page.tsx
+++ b/apps/web/app/utility-providers/page.tsx
@@ -1,0 +1,38 @@
+import { UtilityProvider, ReferralCommission } from '@tenancy/types';
+import { SwitchProviderButton } from '../../components/SwitchProviderButton';
+
+const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001';
+
+async function getProviders(): Promise<UtilityProvider[]> {
+  const res = await fetch(`${apiUrl}/utility-providers`, { cache: 'no-store' });
+  return res.json();
+}
+
+async function getCommissions(): Promise<ReferralCommission[]> {
+  const res = await fetch(`${apiUrl}/utility-providers/referrals`, { cache: 'no-store' });
+  return res.json();
+}
+
+export default async function UtilityProvidersPage() {
+  const [providers, commissions] = await Promise.all([
+    getProviders(),
+    getCommissions(),
+  ]);
+  const totalCommission = commissions.reduce((sum, c) => sum + c.amount, 0);
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-xl font-bold">Utility Providers</h1>
+      {providers.map((p) => (
+        <div key={p.id} className="border p-4 rounded">
+          <h2 className="text-lg font-semibold">{p.name}</h2>
+          <p>Rate: ${p.rate.toFixed(2)} per kWh</p>
+          <p>Estimated Savings: ${p.estimatedSavings.toFixed(2)}</p>
+          <SwitchProviderButton providerId={p.id} />
+        </div>
+      ))}
+      <div className="pt-4 font-medium">
+        Total referral commissions: ${totalCommission.toFixed(2)}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/SwitchProviderButton.tsx
+++ b/apps/web/components/SwitchProviderButton.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import { Button } from '@tenancy/ui';
+
+interface Props {
+  providerId: string;
+}
+
+export function SwitchProviderButton({ providerId }: Props) {
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001';
+  const switchProvider = async () => {
+    await fetch(`${apiUrl}/utility-providers/switch`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ providerId }),
+    });
+    alert('Switched provider');
+  };
+  return <Button label="Switch" onClick={switchProvider} />;
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -116,3 +116,16 @@ export interface Ticket {
   notes: TicketNote[];
   createdAt: Date;
 }
+
+export interface UtilityProvider {
+  id: string;
+  name: string;
+  rate: number;
+  estimatedSavings: number;
+}
+
+export interface ReferralCommission {
+  providerId: string;
+  amount: number;
+}
+


### PR DESCRIPTION
## Summary
- add shared types for utility providers and referral commissions
- expose mock API to list providers, switch provider, and track referral commissions
- add UI page to compare providers with estimated savings and initiate switches

## Testing
- `npm test -w apps/api`
- `npx --yes eslint@8 ...` *(fails: ESLint couldn't find the plugin "@typescript-eslint/eslint-plugin")*

------
https://chatgpt.com/codex/tasks/task_e_68b3fc12912c832eb6dd9008818f2913