### PR TITLE
feat: add deposit tracking and move-out flow

### DIFF
--- a/apps/api/prisma/migrations/20240715130000_add_deposit_fields/migration.sql
+++ b/apps/api/prisma/migrations/20240715130000_add_deposit_fields/migration.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "Deposit"
+  ADD COLUMN "schemeRef" TEXT,
+  ADD COLUMN "protectedAt" TIMESTAMP(3),
+  ADD COLUMN "deductionAmount" DOUBLE PRECISION,
+  ADD COLUMN "approved" BOOLEAN NOT NULL DEFAULT false;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -510,6 +510,10 @@ model Deposit {
   amount     Float
   receivedAt DateTime
   returnedAt DateTime?
+  schemeRef       String?
+  protectedAt     DateTime?
+  deductionAmount Float?
+  approved        Boolean     @default(false)
 }
 
 model Document {

--- a/apps/api/src/lease/lease.controller.ts
+++ b/apps/api/src/lease/lease.controller.ts
@@ -25,6 +25,17 @@ const LeaseShareSchema = z.object({
   value: z.number(),
 });
 
+const DepositCreate = z.object({
+  amount: z.number(),
+  receivedAt: z.string().datetime(),
+  schemeRef: z.string().optional(),
+  protectedAt: z.string().datetime().optional(),
+});
+
+const MoveOut = z.object({
+  deductionAmount: z.number().optional(),
+});
+
 @ApiTags('leases')
 @Controller('leases')
 export class LeaseController {
@@ -67,6 +78,32 @@ export class LeaseController {
   updateShares(@Param('id') id: string, @Body() body: any) {
     const shares = z.array(LeaseShareSchema).parse(body);
     return this.service.updateShares(id, shares);
+  }
+
+  @Get(':id/deposit')
+  getDeposit(@Param('id') id: string) {
+    return this.service.getDeposit(id);
+  }
+
+  @Post(':id/deposit')
+  createDeposit(@Param('id') id: string, @Body() body: any) {
+    const data = DepositCreate.parse(body);
+    return this.service.createDeposit(id, {
+      ...data,
+      receivedAt: new Date(data.receivedAt),
+      protectedAt: data.protectedAt ? new Date(data.protectedAt) : undefined,
+    });
+  }
+
+  @Post(':id/move-out')
+  moveOut(@Param('id') id: string, @Body() body: any) {
+    const data = MoveOut.parse(body);
+    return this.service.recordMoveOut(id, data.deductionAmount);
+  }
+
+  @Post(':id/move-out/approve')
+  approveMoveOut(@Param('id') id: string) {
+    return this.service.approveMoveOut(id);
   }
 
   /** Webhook endpoint for e-sign completion. */

--- a/apps/web/app/leases/[id]/page.tsx
+++ b/apps/web/app/leases/[id]/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useParams } from 'next/navigation';
 import { Button } from '@tenancy/ui';
 import { StatusChip } from '../../../components/StatusChip';
@@ -14,7 +14,15 @@ export default function LeasePage() {
   const id = (params as any).id as string;
   const [pdfUrl, setPdfUrl] = useState<string | null>(null);
   const [signStatus, setSignStatus] = useState<'idle' | 'pending' | 'signed'>('idle');
+  const [deposit, setDeposit] = useState<any | null>(null);
+  const [deduction, setDeduction] = useState(0);
   const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001';
+
+  useEffect(() => {
+    fetch(`${apiUrl}/leases/${id}/deposit`)
+      .then(res => res.json())
+      .then(setDeposit);
+  }, [apiUrl, id]);
 
   const generatePdf = async () => {
     const res = await fetch(`${apiUrl}/leases/${id}/pdf`);
@@ -27,6 +35,22 @@ export default function LeasePage() {
     const data = await res.json();
     setSignStatus('pending');
     if (data.url) window.open(data.url, '_blank');
+  };
+
+  const recordMoveOut = async () => {
+    await fetch(`${apiUrl}/leases/${id}/move-out`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ deductionAmount: deduction }),
+    });
+    const dep = await fetch(`${apiUrl}/leases/${id}/deposit`).then(res => res.json());
+    setDeposit(dep);
+  };
+
+  const approveMoveOut = async () => {
+    await fetch(`${apiUrl}/leases/${id}/move-out/approve`, { method: 'POST' });
+    const dep = await fetch(`${apiUrl}/leases/${id}/deposit`).then(res => res.json());
+    setDeposit(dep);
   };
 
   return (
@@ -50,6 +74,40 @@ export default function LeasePage() {
         <ProviderBadge provider="paypal" />
         <ProviderBadge provider="square" />
       </div>
+      {deposit && (
+        <div className="space-y-2">
+          <div>Deposit Amount: {deposit.amount}</div>
+          {deposit.schemeRef && <div>Scheme Ref: {deposit.schemeRef}</div>}
+          {deposit.protectedAt && (
+            <div>
+              Protected: {new Date(deposit.protectedAt).toLocaleDateString()}
+            </div>
+          )}
+          {deposit.returnedAt && (
+            <div>
+              Returned: {new Date(deposit.returnedAt).toLocaleDateString()}
+            </div>
+          )}
+          {deposit.deductionAmount && (
+            <div>Deduction: {deposit.deductionAmount}</div>
+          )}
+          <div>Status: {deposit.approved ? 'Approved' : 'Pending'}</div>
+          {!deposit.returnedAt && (
+            <div className="space-x-2">
+              <input
+                type="number"
+                value={deduction}
+                onChange={e => setDeduction(parseFloat(e.target.value))}
+                className="border p-1"
+              />
+              <Button onClick={recordMoveOut}>Record Move-out</Button>
+            </div>
+          )}
+          {deposit.returnedAt && !deposit.approved && (
+            <Button onClick={approveMoveOut}>Approve Deduction</Button>
+          )}
+        </div>
+      )}
       <div className="flex space-x-2">
         {pdfUrl && <StatusChip text="PDF generated" color="green" />}
         {signStatus === 'pending' && <StatusChip text="Signature pending" color="yellow" />}


### PR DESCRIPTION
## Summary
- expand deposit model with scheme reference, protection date, deductions and approval flag
- expose API endpoints for deposit management and move-out approval
- display deposit details and move-out actions on lease page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: turbo: not found)*
- `npm run typecheck` *(fails: turbo: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3ff24fe3c832e88b189d4f1f32894