### PR TITLE
feat: add deposit insurance option

### DIFF
--- a/apps/api/src/lease/lease.controller.ts
+++ b/apps/api/src/lease/lease.controller.ts
@@ -85,6 +85,12 @@ export class LeaseController {
     return this.service.getDeposit(id);
   }
 
+  /** Get deposit alternative insurance quote with billing & policy docs */
+  @Get(':id/deposit/insurance')
+  getDepositInsurance(@Param('id') id: string) {
+    return this.service.getDepositInsuranceQuote(id);
+  }
+
   @Post(':id/deposit')
   createDeposit(@Param('id') id: string, @Body() body: any) {
     const data = DepositCreate.parse(body);

--- a/apps/api/src/lease/lease.service.ts
+++ b/apps/api/src/lease/lease.service.ts
@@ -5,6 +5,7 @@ import { LeaseRepository } from './lease.repository';
 import { PdfService } from './pdf.service';
 import { EsignService } from './esign.service';
 import { PrismaService } from '../prisma.service';
+import { DepositInsuranceQuote } from '@tenancy/types';
 
 @Injectable({ scope: Scope.REQUEST })
 export class LeaseService {
@@ -86,6 +87,20 @@ export class LeaseService {
 
   getDeposit(leaseId: string) {
     return this.prisma.deposit.findFirst({ where: { leaseId, orgId: this.orgId } });
+  }
+
+  /** Return a deposit insurance quote including billing and policy details. */
+  async getDepositInsuranceQuote(leaseId: string): Promise<DepositInsuranceQuote> {
+    const lease = await this.repo.findUnique(leaseId);
+    if (!lease) throw new Error('Lease not found');
+    const depositAmount = lease.depositAmount ?? 0;
+    const cost = Math.round(depositAmount * 0.05 * 100) / 100;
+    return {
+      depositAmount,
+      cost,
+      billingFrequency: 'monthly',
+      policyUrl: 'https://example.com/policies/deposit-insurance.pdf',
+    };
   }
 
   createDeposit(

--- a/apps/web/app/leases/[id]/page.tsx
+++ b/apps/web/app/leases/[id]/page.tsx
@@ -8,6 +8,7 @@ import { AutopayToggle } from '../../../components/AutopayToggle';
 import { PayNowButton } from '../../../components/PayNowButton';
 import { ProviderBadge } from '../../../components/ProviderBadge';
 import Link from 'next/link';
+import { DepositInsuranceQuote } from '@tenancy/types';
 
 export default function LeasePage() {
   const params = useParams();
@@ -15,6 +16,7 @@ export default function LeasePage() {
   const [pdfUrl, setPdfUrl] = useState<string | null>(null);
   const [signStatus, setSignStatus] = useState<'idle' | 'pending' | 'signed'>('idle');
   const [deposit, setDeposit] = useState<any | null>(null);
+  const [insurance, setInsurance] = useState<DepositInsuranceQuote | null>(null);
   const [deduction, setDeduction] = useState(0);
   const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001';
 
@@ -22,6 +24,12 @@ export default function LeasePage() {
     fetch(`${apiUrl}/leases/${id}/deposit`)
       .then(res => res.json())
       .then(setDeposit);
+  }, [apiUrl, id]);
+
+  useEffect(() => {
+    fetch(`${apiUrl}/leases/${id}/deposit/insurance`)
+      .then(res => res.json())
+      .then(setInsurance);
   }, [apiUrl, id]);
 
   const generatePdf = async () => {
@@ -106,6 +114,20 @@ export default function LeasePage() {
           {deposit.returnedAt && !deposit.approved && (
             <Button onClick={approveMoveOut}>Approve Deduction</Button>
           )}
+        </div>
+      )}
+      {insurance && (
+        <div className="space-y-2">
+          <div>
+            Insurance Premium: {insurance.cost} ({insurance.billingFrequency})
+          </div>
+          <div>Cash Deposit: {insurance.depositAmount}</div>
+          <div>
+            Upfront Savings: {insurance.depositAmount - insurance.cost}
+          </div>
+          <Link href={insurance.policyUrl} className="underline">
+            View policy
+          </Link>
         </div>
       )}
       <div className="flex space-x-2">

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -129,3 +129,14 @@ export interface ReferralCommission {
   amount: number;
 }
 
+export interface DepositInsuranceQuote {
+  /** Amount of traditional cash deposit */
+  depositAmount: number;
+  /** Recurring insurance premium cost */
+  cost: number;
+  /** Billing frequency for the premium, e.g. monthly */
+  billingFrequency: string;
+  /** URL to the insurance policy document */
+  policyUrl: string;
+}
+


### PR DESCRIPTION
## Summary
- add DepositInsuranceQuote type for insurance details
- implement API route to return deposit insurance quotes
- display insurance cost vs cash deposit with policy link on lease page

## Testing
- `npm run lint` *(fails: sh: 1: turbo: not found)*
- `npm run typecheck` *(fails: sh: 1: turbo: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b40f5af274832eb3f81f730d87c3e9