### PR TITLE
feat: add analytics dashboards

### DIFF
--- a/apps/api/src/analytics/analytics.controller.ts
+++ b/apps/api/src/analytics/analytics.controller.ts
@@ -1,0 +1,53 @@
+import { Controller, Get, Query } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import { z } from 'zod';
+import { AnalyticsService } from './analytics.service';
+
+const Filters = z.object({
+  startDate: z.string().optional(),
+  endDate: z.string().optional(),
+  propertyId: z.string().optional(),
+  unitId: z.string().optional(),
+});
+
+function parseFilters(query: any) {
+  const { startDate, endDate, propertyId, unitId } = Filters.parse(query);
+  return {
+    startDate: startDate ? new Date(startDate) : undefined,
+    endDate: endDate ? new Date(endDate) : undefined,
+    propertyId,
+    unitId,
+  };
+}
+
+@ApiTags('analytics')
+@Controller('analytics')
+export class AnalyticsController {
+  constructor(private service: AnalyticsService) {}
+
+  @Get('arrears')
+  arrears(@Query() query: any) {
+    return this.service.arrears(parseFilters(query));
+  }
+
+  @Get('dso')
+  dso(@Query() query: any) {
+    return this.service.dso(parseFilters(query));
+  }
+
+  @Get('on-time-rate')
+  onTime(@Query() query: any) {
+    return this.service.onTimePaymentRate(parseFilters(query));
+  }
+
+  @Get('mttr')
+  mttr(@Query() query: any) {
+    return this.service.mttr(parseFilters(query));
+  }
+
+  @Get('utility-overage')
+  overage(@Query() query: any) {
+    return this.service.utilityOverage(parseFilters(query));
+  }
+}
+

--- a/apps/api/src/analytics/analytics.service.ts
+++ b/apps/api/src/analytics/analytics.service.ts
@@ -1,0 +1,151 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma.service';
+
+type Filters = {
+  startDate?: Date;
+  endDate?: Date;
+  propertyId?: string;
+  unitId?: string;
+};
+
+@Injectable()
+export class AnalyticsService {
+  constructor(private prisma: PrismaService) {}
+
+  private buildInvoiceWhere(filters: Filters) {
+    const date: any = {};
+    if (filters.startDate) date.gte = filters.startDate;
+    if (filters.endDate) date.lte = filters.endDate;
+    return {
+      ...(filters.startDate || filters.endDate ? { dueDate: date } : {}),
+      ...(filters.unitId || filters.propertyId
+        ? {
+            lease: {
+              ...(filters.unitId ? { unitId: filters.unitId } : {}),
+              ...(filters.propertyId
+                ? { unit: { propertyId: filters.propertyId } }
+                : {}),
+            },
+          }
+        : {}),
+    };
+  }
+
+  private buildTicketWhere(filters: Filters) {
+    const date: any = {};
+    if (filters.startDate) date.gte = filters.startDate;
+    if (filters.endDate) date.lte = filters.endDate;
+    return {
+      status: 'completed',
+      ...(filters.startDate || filters.endDate ? { createdAt: date } : {}),
+      ...(filters.unitId ? { unitId: filters.unitId } : {}),
+      ...(filters.propertyId ? { propertyId: filters.propertyId } : {}),
+    };
+  }
+
+  private buildReadingWhere(filters: Filters) {
+    const date: any = {};
+    if (filters.startDate) date.gte = filters.startDate;
+    if (filters.endDate) date.lte = filters.endDate;
+    return {
+      ...(filters.startDate || filters.endDate ? { recordedAt: date } : {}),
+      ...(filters.unitId
+        ? { unitId: filters.unitId }
+        : filters.propertyId
+        ? { unit: { propertyId: filters.propertyId } }
+        : {}),
+    };
+  }
+
+  async arrears(filters: Filters) {
+    const invoices = await this.prisma.invoice.findMany({
+      where: this.buildInvoiceWhere(filters),
+      include: { payments: true },
+    });
+    let total = 0;
+    for (const inv of invoices) {
+      const paid = inv.payments.reduce((s, p) => s + p.amount, 0);
+      const outstanding = inv.amount - paid;
+      if (outstanding > 0) total += outstanding;
+    }
+    return { arrears: total };
+  }
+
+  async dso(filters: Filters) {
+    const invoices = await this.prisma.invoice.findMany({
+      where: {
+        ...this.buildInvoiceWhere(filters),
+        paidAt: { not: null },
+      },
+    });
+    const days = invoices.reduce((sum, inv) => {
+      if (!inv.paidAt) return sum;
+      const diff =
+        (inv.paidAt.getTime() - inv.dueDate.getTime()) / (1000 * 60 * 60 * 24);
+      return sum + diff;
+    }, 0);
+    const avg = invoices.length ? days / invoices.length : 0;
+    return { dso: avg };
+  }
+
+  async onTimePaymentRate(filters: Filters) {
+    const invoices = await this.prisma.invoice.findMany({
+      where: {
+        ...this.buildInvoiceWhere(filters),
+        paidAt: { not: null },
+      },
+    });
+    const onTime = invoices.filter(
+      (inv) => inv.paidAt && inv.paidAt <= inv.dueDate,
+    ).length;
+    const rate = invoices.length ? onTime / invoices.length : 0;
+    return { rate };
+  }
+
+  async mttr(filters: Filters) {
+    const tickets = await this.prisma.ticket.findMany({
+      where: this.buildTicketWhere(filters),
+      include: { visits: true },
+    });
+    let total = 0;
+    let count = 0;
+    for (const ticket of tickets) {
+      const visit = ticket.visits.find((v) => v.outcome === 'completed');
+      if (visit) {
+        const diff =
+          (visit.scheduledAt.getTime() - ticket.createdAt.getTime()) /
+          (1000 * 60 * 60);
+        total += diff;
+        count++;
+      }
+    }
+    return { mttr: count ? total / count : 0 };
+  }
+
+  async utilityOverage(filters: Filters) {
+    const readings = await this.prisma.utilityReading.findMany({
+      where: this.buildReadingWhere(filters),
+      include: {
+        unit: {
+          include: {
+            leases: { where: { status: 'active' } },
+          },
+        },
+      },
+    });
+    let overage = 0;
+    for (const r of readings) {
+      const lease = r.unit.leases[0];
+      let allowance = 0;
+      if (lease && lease.utilityAllowances) {
+        const allowances = lease.utilityAllowances as any;
+        allowance = allowances[r.type] ?? 0;
+      }
+      if (r.reading > allowance) {
+        overage += r.reading - allowance;
+      }
+    }
+    return { overage };
+  }
+}
+

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -75,6 +75,8 @@ import { GreenScoreRepository } from './green/green-score.repository';
 import { GreenService } from './green/green.service';
 import { UtilityProviderController } from './utility-provider/utility-provider.controller';
 import { UtilityProviderService } from './utility-provider/utility-provider.service';
+import { AnalyticsController } from './analytics/analytics.controller';
+import { AnalyticsService } from './analytics/analytics.service';
 
 @Module({
   imports: [
@@ -110,6 +112,7 @@ import { UtilityProviderService } from './utility-provider/utility-provider.serv
     AssessmentController,
     UtilityReadingController,
     UtilityProviderController,
+    AnalyticsController,
   ],
   providers: [
     AppService,
@@ -160,6 +163,7 @@ import { UtilityProviderService } from './utility-provider/utility-provider.serv
     GreenScoreRepository,
     GreenService,
     UtilityProviderService,
+    AnalyticsService,
     {
       provide: SMART_METER_CONNECTOR,
       useClass: MockSmartMeterConnector,

--- a/apps/web/app/analytics/page.tsx
+++ b/apps/web/app/analytics/page.tsx
@@ -1,0 +1,123 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || '';
+
+type Filters = {
+  startDate: string;
+  endDate: string;
+  propertyId: string;
+  unitId: string;
+};
+
+type Metrics = {
+  arrears: number;
+  dso: number;
+  rate: number;
+  mttr: number;
+  overage: number;
+};
+
+export default function AnalyticsPage() {
+  const [filters, setFilters] = useState<Filters>({
+    startDate: '',
+    endDate: '',
+    propertyId: '',
+    unitId: '',
+  });
+  const [metrics, setMetrics] = useState<Metrics | null>(null);
+
+  useEffect(() => {
+    const params = new URLSearchParams();
+    Object.entries(filters).forEach(([k, v]) => {
+      if (v) params.append(k, v);
+    });
+    const query = params.toString();
+    async function load() {
+      const [a, d, r, m, o] = await Promise.all([
+        fetch(`${API_URL}/analytics/arrears?${query}`).then((res) => res.json()),
+        fetch(`${API_URL}/analytics/dso?${query}`).then((res) => res.json()),
+        fetch(`${API_URL}/analytics/on-time-rate?${query}`).then((res) =>
+          res.json(),
+        ),
+        fetch(`${API_URL}/analytics/mttr?${query}`).then((res) => res.json()),
+        fetch(`${API_URL}/analytics/utility-overage?${query}`).then((res) =>
+          res.json(),
+        ),
+      ]);
+      setMetrics({
+        arrears: a.arrears ?? 0,
+        dso: d.dso ?? 0,
+        rate: r.rate ?? 0,
+        mttr: m.mttr ?? 0,
+        overage: o.overage ?? 0,
+      });
+    }
+    load();
+  }, [filters]);
+
+  function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
+    setFilters({ ...filters, [e.target.name]: e.target.value });
+  }
+
+  return (
+    <div className="p-4 space-y-4">
+      <div className="flex flex-wrap gap-2">
+        <input
+          type="date"
+          name="startDate"
+          value={filters.startDate}
+          onChange={handleChange}
+          className="border p-1"
+        />
+        <input
+          type="date"
+          name="endDate"
+          value={filters.endDate}
+          onChange={handleChange}
+          className="border p-1"
+        />
+        <input
+          type="text"
+          name="propertyId"
+          placeholder="Property ID"
+          value={filters.propertyId}
+          onChange={handleChange}
+          className="border p-1"
+        />
+        <input
+          type="text"
+          name="unitId"
+          placeholder="Unit ID"
+          value={filters.unitId}
+          onChange={handleChange}
+          className="border p-1"
+        />
+      </div>
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+        <div className="p-4 border rounded">
+          <h2 className="font-semibold mb-2">Arrears</h2>
+          <p>{metrics ? metrics.arrears.toFixed(2) : '-'}</p>
+        </div>
+        <div className="p-4 border rounded">
+          <h2 className="font-semibold mb-2">DSO</h2>
+          <p>{metrics ? metrics.dso.toFixed(2) : '-'}</p>
+        </div>
+        <div className="p-4 border rounded">
+          <h2 className="font-semibold mb-2">On-time Payment Rate</h2>
+          <p>{metrics ? (metrics.rate * 100).toFixed(2) : '-'}%</p>
+        </div>
+        <div className="p-4 border rounded">
+          <h2 className="font-semibold mb-2">MTTR (hrs)</h2>
+          <p>{metrics ? metrics.mttr.toFixed(2) : '-'}</p>
+        </div>
+        <div className="p-4 border rounded">
+          <h2 className="font-semibold mb-2">Utility Overage</h2>
+          <p>{metrics ? metrics.overage.toFixed(2) : '-'}</p>
+        </div>
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add backend analytics service with metrics for arrears, DSO, on-time payment rate, MTTR, and utility overage
- expose analytics endpoints and register in app module
- add client dashboard page with filters and metric cards

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: turbo: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4142a9494832e9f472fb2e1412e80