### PR TITLE
feat: add market analytics comparison

### DIFF
--- a/apps/api/src/analytics/analytics.controller.ts
+++ b/apps/api/src/analytics/analytics.controller.ts
@@ -10,6 +10,12 @@ const Filters = z.object({
   unitId: z.string().optional(),
 });
 
+const Market = z.object({
+  area: z.string().optional(),
+  yield: z.coerce.number(),
+  vacancy: z.coerce.number(),
+});
+
 function parseFilters(query: any) {
   const { startDate, endDate, propertyId, unitId } = Filters.parse(query);
   return {
@@ -48,6 +54,12 @@ export class AnalyticsController {
   @Get('utility-overage')
   overage(@Query() query: any) {
     return this.service.utilityOverage(parseFilters(query));
+  }
+
+  @Get('market-comparison')
+  market(@Query() query: any) {
+    const { area, yield: y, vacancy } = Market.parse(query);
+    return this.service.marketComparison(area ?? '', y, vacancy);
   }
 }
 

--- a/apps/api/src/analytics/analytics.service.ts
+++ b/apps/api/src/analytics/analytics.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../prisma.service';
+import { MarketDataService } from './market-data.service';
 
 type Filters = {
   startDate?: Date;
@@ -10,7 +11,10 @@ type Filters = {
 
 @Injectable()
 export class AnalyticsService {
-  constructor(private prisma: PrismaService) {}
+  constructor(
+    private prisma: PrismaService,
+    private market: MarketDataService,
+  ) {}
 
   private buildInvoiceWhere(filters: Filters) {
     const date: any = {};
@@ -146,6 +150,10 @@ export class AnalyticsService {
       }
     }
     return { overage };
+  }
+
+  async marketComparison(area: string, yieldRate: number, vacancy: number) {
+    return this.market.compare(area, yieldRate, vacancy);
   }
 }
 

--- a/apps/api/src/analytics/market-data.json
+++ b/apps/api/src/analytics/market-data.json
@@ -1,0 +1,7 @@
+[
+  { "area": "Central", "yield": 5.1, "vacancy": 3.2 },
+  { "area": "North", "yield": 4.8, "vacancy": 4.1 },
+  { "area": "South", "yield": 5.5, "vacancy": 2.5 },
+  { "area": "East", "yield": 4.2, "vacancy": 5.7 },
+  { "area": "West", "yield": 5.0, "vacancy": 3.9 }
+]

--- a/apps/api/src/analytics/market-data.service.ts
+++ b/apps/api/src/analytics/market-data.service.ts
@@ -1,0 +1,44 @@
+import { Injectable } from '@nestjs/common';
+import { readFile } from 'fs/promises';
+import { join } from 'path';
+
+interface MarketRecord {
+  area: string;
+  yield: number;
+  vacancy: number;
+}
+
+@Injectable()
+export class MarketDataService {
+  private cache: MarketRecord[] | null = null;
+
+  private async load(): Promise<MarketRecord[]> {
+    if (!this.cache) {
+      const file = await readFile(join(__dirname, 'market-data.json'), 'utf8');
+      this.cache = JSON.parse(file) as MarketRecord[];
+    }
+    return this.cache;
+  }
+
+  async compare(area: string, localYield: number, localVacancy: number) {
+    const data = await this.load();
+    const yields = data.map((d) => d.yield);
+    const vacancies = data.map((d) => d.vacancy);
+    const yieldPercentile = this.percentileRank(yields, localYield);
+    const vacancyPercentile = this.percentileRank(vacancies, localVacancy);
+    const region = data.find((d) => d.area === area);
+    return {
+      area,
+      marketYield: region?.yield ?? null,
+      marketVacancy: region?.vacancy ?? null,
+      yieldPercentile,
+      vacancyPercentile,
+    };
+  }
+
+  private percentileRank(values: number[], value: number) {
+    const sorted = [...values].sort((a, b) => a - b);
+    const below = sorted.filter((v) => v <= value).length;
+    return Math.round((below / sorted.length) * 100);
+  }
+}

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -77,6 +77,7 @@ import { UtilityProviderController } from './utility-provider/utility-provider.c
 import { UtilityProviderService } from './utility-provider/utility-provider.service';
 import { AnalyticsController } from './analytics/analytics.controller';
 import { AnalyticsService } from './analytics/analytics.service';
+import { MarketDataService } from './analytics/market-data.service';
 
 @Module({
   imports: [
@@ -164,6 +165,7 @@ import { AnalyticsService } from './analytics/analytics.service';
     GreenService,
     UtilityProviderService,
     AnalyticsService,
+    MarketDataService,
     {
       provide: SMART_METER_CONNECTOR,
       useClass: MockSmartMeterConnector,

--- a/apps/web/app/analytics/page.tsx
+++ b/apps/web/app/analytics/page.tsx
@@ -9,6 +9,9 @@ type Filters = {
   endDate: string;
   propertyId: string;
   unitId: string;
+  area: string;
+  yield: string;
+  vacancy: string;
 };
 
 type Metrics = {
@@ -17,6 +20,8 @@ type Metrics = {
   rate: number;
   mttr: number;
   overage: number;
+  yieldPercentile: number;
+  vacancyPercentile: number;
 };
 
 export default function AnalyticsPage() {
@@ -25,6 +30,9 @@ export default function AnalyticsPage() {
     endDate: '',
     propertyId: '',
     unitId: '',
+    area: '',
+    yield: '',
+    vacancy: '',
   });
   const [metrics, setMetrics] = useState<Metrics | null>(null);
 
@@ -35,7 +43,7 @@ export default function AnalyticsPage() {
     });
     const query = params.toString();
     async function load() {
-      const [a, d, r, m, o] = await Promise.all([
+      const [a, d, r, m, o, p] = await Promise.all([
         fetch(`${API_URL}/analytics/arrears?${query}`).then((res) => res.json()),
         fetch(`${API_URL}/analytics/dso?${query}`).then((res) => res.json()),
         fetch(`${API_URL}/analytics/on-time-rate?${query}`).then((res) =>
@@ -45,6 +53,9 @@ export default function AnalyticsPage() {
         fetch(`${API_URL}/analytics/utility-overage?${query}`).then((res) =>
           res.json(),
         ),
+        fetch(`${API_URL}/analytics/market-comparison?${query}`).then((res) =>
+          res.json(),
+        ),
       ]);
       setMetrics({
         arrears: a.arrears ?? 0,
@@ -52,6 +63,8 @@ export default function AnalyticsPage() {
         rate: r.rate ?? 0,
         mttr: m.mttr ?? 0,
         overage: o.overage ?? 0,
+        yieldPercentile: p.yieldPercentile ?? 0,
+        vacancyPercentile: p.vacancyPercentile ?? 0,
       });
     }
     load();
@@ -94,6 +107,30 @@ export default function AnalyticsPage() {
           onChange={handleChange}
           className="border p-1"
         />
+        <input
+          type="text"
+          name="area"
+          placeholder="Area"
+          value={filters.area}
+          onChange={handleChange}
+          className="border p-1"
+        />
+        <input
+          type="number"
+          name="yield"
+          placeholder="Yield %"
+          value={filters.yield}
+          onChange={handleChange}
+          className="border p-1"
+        />
+        <input
+          type="number"
+          name="vacancy"
+          placeholder="Vacancy %"
+          value={filters.vacancy}
+          onChange={handleChange}
+          className="border p-1"
+        />
       </div>
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
         <div className="p-4 border rounded">
@@ -115,6 +152,15 @@ export default function AnalyticsPage() {
         <div className="p-4 border rounded">
           <h2 className="font-semibold mb-2">Utility Overage</h2>
           <p>{metrics ? metrics.overage.toFixed(2) : '-'}</p>
+        </div>
+        <div className="p-4 border rounded">
+          <h2 className="font-semibold mb-2">Market Percentiles</h2>
+          <p>
+            Yield: {metrics ? metrics.yieldPercentile.toFixed(0) : '-'}%
+          </p>
+          <p>
+            Vacancy: {metrics ? metrics.vacancyPercentile.toFixed(0) : '-'}%
+          </p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add sample market dataset and service to compute yield and vacancy percentiles
- expose market comparison endpoint in analytics API
- show market percentile card on analytics dashboard

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: turbo: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b41708cc58832e9c0936246e623f20