### PR TITLE
feat: add basic risk modeling

### DIFF
--- a/apps/api/src/analytics/analytics.controller.ts
+++ b/apps/api/src/analytics/analytics.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Query } from '@nestjs/common';
+import { Controller, Get, Param, Query } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { z } from 'zod';
 import { AnalyticsService } from './analytics.service';
@@ -60,6 +60,11 @@ export class AnalyticsController {
   market(@Query() query: any) {
     const { area, yield: y, vacancy } = Market.parse(query);
     return this.service.marketComparison(area ?? '', y, vacancy);
+  }
+
+  @Get('risk/:leaseId')
+  risk(@Param('leaseId') id: string) {
+    return this.service.risk(id);
   }
 }
 

--- a/apps/api/src/analytics/analytics.service.ts
+++ b/apps/api/src/analytics/analytics.service.ts
@@ -11,10 +11,108 @@ type Filters = {
 
 @Injectable()
 export class AnalyticsService {
+  private churnWeights = [0, 0, 0];
+
   constructor(
     private prisma: PrismaService,
     private market: MarketDataService,
-  ) {}
+  ) {
+    this.trainChurnModel();
+  }
+
+  private sigmoid(z: number) {
+    return 1 / (1 + Math.exp(-z));
+  }
+
+  private trainChurnModel() {
+    const data = [
+      { x: [0, 0], y: 0 },
+      { x: [1, 0], y: 0 },
+      { x: [0, 1], y: 0 },
+      { x: [1, 1], y: 1 },
+      { x: [2, 1], y: 1 },
+      { x: [3, 2], y: 1 },
+    ];
+    const lr = 0.1;
+    const iterations = 500;
+    for (let i = 0; i < iterations; i++) {
+      const grad = [0, 0, 0];
+      for (const p of data) {
+        const x = [1, ...p.x];
+        const z =
+          this.churnWeights[0] * x[0] +
+          this.churnWeights[1] * x[1] +
+          this.churnWeights[2] * x[2];
+        const pred = this.sigmoid(z);
+        const err = pred - p.y;
+        grad[0] += err * x[0];
+        grad[1] += err * x[1];
+        grad[2] += err * x[2];
+      }
+      for (let j = 0; j < this.churnWeights.length; j++) {
+        this.churnWeights[j] -= (lr * grad[j]) / data.length;
+      }
+    }
+  }
+
+  private predictChurn(features: number[]) {
+    const z =
+      this.churnWeights[0] +
+      this.churnWeights[1] * features[0] +
+      this.churnWeights[2] * features[1];
+    return this.sigmoid(z);
+  }
+
+  private linearRegression(xs: number[], ys: number[]) {
+    const n = xs.length;
+    const xMean = xs.reduce((a, b) => a + b, 0) / n;
+    const yMean = ys.reduce((a, b) => a + b, 0) / n;
+    let num = 0;
+    let den = 0;
+    for (let i = 0; i < n; i++) {
+      num += (xs[i] - xMean) * (ys[i] - yMean);
+      den += (xs[i] - xMean) ** 2;
+    }
+    const slope = den === 0 ? 0 : num / den;
+    const intercept = yMean - slope * xMean;
+    return { slope, intercept };
+  }
+
+  private forecastMaintenance(tickets: any[]) {
+    const costsByMonth = new Map<number, number>();
+    for (const t of tickets) {
+      if (t.status !== 'completed') continue;
+      const month = t.createdAt.getFullYear() * 12 + t.createdAt.getMonth();
+      const cost = (t.partsCost ?? 0) + (t.labourCost ?? 0);
+      costsByMonth.set(month, (costsByMonth.get(month) ?? 0) + cost);
+    }
+    const data = Array.from(costsByMonth.entries()).sort((a, b) => a[0] - b[0]);
+    if (data.length === 0) return 0;
+    if (data.length === 1) return data[0][1];
+    const xs = data.map(([m]) => m);
+    const ys = data.map(([, c]) => c);
+    const { slope, intercept } = this.linearRegression(xs, ys);
+    const next = data[data.length - 1][0] + 1;
+    return intercept + slope * next;
+  }
+
+  async risk(leaseId: string) {
+    const lease = await this.prisma.lease.findUnique({
+      where: { id: leaseId },
+      include: { invoices: true, unit: { include: { tickets: true } } },
+    });
+    if (!lease) return { churnRisk: 0, maintenanceForecast: 0 };
+    const late = lease.invoices.filter((inv) => {
+      if (inv.paidAt) return inv.paidAt > inv.dueDate;
+      return inv.dueDate < new Date();
+    }).length;
+    const maintenanceTickets = lease.unit.tickets.filter(
+      (t: any) => t.status === 'completed',
+    );
+    const churnRisk = this.predictChurn([late, maintenanceTickets.length]);
+    const maintenanceForecast = this.forecastMaintenance(lease.unit.tickets);
+    return { churnRisk, maintenanceForecast };
+  }
 
   private buildInvoiceWhere(filters: Filters) {
     const date: any = {};

--- a/apps/web/app/leases/[id]/page.tsx
+++ b/apps/web/app/leases/[id]/page.tsx
@@ -18,6 +18,10 @@ export default function LeasePage() {
   const [deposit, setDeposit] = useState<any | null>(null);
   const [insurance, setInsurance] = useState<DepositInsuranceQuote | null>(null);
   const [deduction, setDeduction] = useState(0);
+  const [risk, setRisk] = useState<
+    | { churnRisk: number; maintenanceForecast: number }
+    | null
+  >(null);
   const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001';
 
   useEffect(() => {
@@ -30,6 +34,12 @@ export default function LeasePage() {
     fetch(`${apiUrl}/leases/${id}/deposit/insurance`)
       .then(res => res.json())
       .then(setInsurance);
+  }, [apiUrl, id]);
+
+  useEffect(() => {
+    fetch(`${apiUrl}/analytics/risk/${id}`)
+      .then(res => res.json())
+      .then(setRisk);
   }, [apiUrl, id]);
 
   const generatePdf = async () => {
@@ -82,6 +92,12 @@ export default function LeasePage() {
         <ProviderBadge provider="paypal" />
         <ProviderBadge provider="square" />
       </div>
+      {risk && (
+        <div className="space-y-1">
+          <div>Churn Risk: {(risk.churnRisk * 100).toFixed(0)}%</div>
+          <div>Maintenance Forecast: ${risk.maintenanceForecast.toFixed(2)}</div>
+        </div>
+      )}
       {deposit && (
         <div className="space-y-2">
           <div>Deposit Amount: {deposit.amount}</div>


### PR DESCRIPTION
## Summary
- add logistic churn model and maintenance cost forecast
- expose risk scoring endpoint
- display risk scores on lease page

## Testing
- `npm test -w apps/api`
- `npm run lint -w apps/api` *(fails: ESLint couldn't find config file)*
- `npm run lint -w apps/web` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b417fc8340832ebc2c0837fc86b4e2