### PR TITLE
feat: enhance internationalization and formatting

### DIFF
--- a/apps/web/app/invoices/[id]/shares/page.tsx
+++ b/apps/web/app/invoices/[id]/shares/page.tsx
@@ -1,37 +1,35 @@
-'use client';
+import i18n from '@/i18n';
+import { formatCurrency } from '@/lib/format';
+import { headers } from 'next/headers';
 
-import { useEffect, useState } from 'react';
-import { useParams } from 'next/navigation';
+interface Share {
+  membershipId: string;
+  amount: number;
+  currency?: string;
+}
 
-export default function InvoiceSharesPage() {
-  const params = useParams();
-  const id = (params as any).id as string;
+export default async function InvoiceSharesPage({ params }: { params: { id: string } }) {
   const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001';
-  const [shares, setShares] = useState<any[]>([]);
+  const res = await fetch(`${apiUrl}/invoices/${params.id}/shares`);
+  const shares: Share[] = await res.json();
 
-  useEffect(() => {
-    const fetchShares = async () => {
-      const res = await fetch(`${apiUrl}/invoices/${id}/shares`);
-      const data = await res.json();
-      setShares(data);
-    };
-    fetchShares();
-  }, [id]);
+  const locale = headers().get('accept-language')?.split(',')[0] || 'en-US';
+  const t = i18n.getFixedT(locale, 'invoices');
 
   return (
     <div className="space-y-4">
       <table className="min-w-full text-sm">
         <thead>
           <tr>
-            <th>Member</th>
-            <th>Amount</th>
+            <th>{t('member')}</th>
+            <th>{t('amount')}</th>
           </tr>
         </thead>
         <tbody>
           {shares.map(share => (
             <tr key={share.membershipId}>
               <td>{share.membershipId}</td>
-              <td>{share.amount}</td>
+              <td>{formatCurrency(share.amount, share.currency || 'USD', locale)}</td>
             </tr>
           ))}
         </tbody>

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -2,12 +2,14 @@
 
 import { useTranslation } from 'react-i18next';
 import { Button } from '@tenancy/ui';
+import LanguageSwitcher from '@/components/LanguageSwitcher';
 
 export default function Page() {
-  const { t } = useTranslation();
+  const { t } = useTranslation('common');
   return (
-    <main className="p-4">
-      <h1 className="text-xl mb-4">{t('welcome')}</h1>
+    <main className="p-4 space-y-4">
+      <LanguageSwitcher />
+      <h1 className="text-xl">{t('welcome')}</h1>
       <Button label={t('clickMe')} />
     </main>
   );

--- a/apps/web/components/LanguageSwitcher.tsx
+++ b/apps/web/components/LanguageSwitcher.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import { useTranslation } from 'react-i18next';
+
+export default function LanguageSwitcher() {
+  const { i18n } = useTranslation();
+
+  const changeLanguage = (lng: string) => {
+    i18n.changeLanguage(lng);
+  };
+
+  return (
+    <div className="space-x-2">
+      <button onClick={() => changeLanguage('en')} disabled={i18n.language === 'en'}>
+        EN
+      </button>
+      <button onClick={() => changeLanguage('es')} disabled={i18n.language === 'es'}>
+        ES
+      </button>
+    </div>
+  );
+}

--- a/apps/web/i18n.ts
+++ b/apps/web/i18n.ts
@@ -2,14 +2,22 @@ import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
 
 const resources = {
-  en: { translation: { welcome: 'Welcome', clickMe: 'Click me' } },
-  es: { translation: { welcome: 'Bienvenido', clickMe: 'Haga clic' } },
+  en: {
+    common: { welcome: 'Welcome', clickMe: 'Click me', language: 'Language' },
+    invoices: { member: 'Member', amount: 'Amount' },
+  },
+  es: {
+    common: { welcome: 'Bienvenido', clickMe: 'Haga clic', language: 'Idioma' },
+    invoices: { member: 'Miembro', amount: 'Cantidad' },
+  },
 };
 
 i18n.use(initReactI18next).init({
   resources,
   lng: 'en',
   fallbackLng: 'en',
+  ns: ['common', 'invoices'],
+  defaultNS: 'common',
   interpolation: { escapeValue: false },
 });
 

--- a/apps/web/lib/format.ts
+++ b/apps/web/lib/format.ts
@@ -1,0 +1,20 @@
+export function formatCurrency(value: number, currency: string, locale = 'en-US') {
+  return new Intl.NumberFormat(locale, { style: 'currency', currency }).format(value);
+}
+
+export function formatNumber(
+  value: number,
+  locale = 'en-US',
+  options: Intl.NumberFormatOptions = {}
+) {
+  return new Intl.NumberFormat(locale, options).format(value);
+}
+
+export function formatDate(
+  date: string | number | Date,
+  locale = 'en-US',
+  timeZone = 'UTC',
+  options: Intl.DateTimeFormatOptions = {}
+) {
+  return new Intl.DateTimeFormat(locale, { timeZone, ...options }).format(new Date(date));
+}


### PR DESCRIPTION
## Summary
- add i18next namespaces for common and invoice translations
- provide language switcher component
- format currency and numbers server-side with locale support

## Testing
- `npm run lint -- --filter=web` *(fails: turbo: not found)*
- `npm install` *(fails: Unsupported URL Type "workspace:" workspace:*)
- `npm run typecheck -- --filter=web` *(fails: turbo: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b41f9be6d0832e8fe8c15ab5ffa091