### PR TITLE
feat: add api key module with rate limiting

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -19,6 +19,7 @@
     "@nestjs/passport": "^11.0.5",
     "@nestjs/schedule": "^2.2.0",
     "@nestjs/bull": "^10.0.0",
+    "@nestjs/throttler": "^4.0.0",
     "@prisma/client": "^5.4.1",
     "@aws-sdk/client-s3": "^3.454.0",
     "@aws-sdk/s3-request-presigner": "^3.454.0",

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -556,6 +556,9 @@ model ApiKey {
   org        Organization @relation(fields: [orgId], references: [id])
   orgId      String
   key        String       @unique
+  scopes     String[]
+  quota      Int
+  usage      Int          @default(0)
   createdAt  DateTime     @default(now())
   lastUsedAt DateTime?
 }

--- a/apps/api/src/analytics/analytics.controller.ts
+++ b/apps/api/src/analytics/analytics.controller.ts
@@ -1,7 +1,8 @@
-import { Controller, Get, Param, Query } from '@nestjs/common';
+import { Controller, Get, Param, Query, UseGuards } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { z } from 'zod';
 import { AnalyticsService } from './analytics.service';
+import { ApiKeyGuard } from '../api-key/api-key.guard';
 
 const Filters = z.object({
   startDate: z.string().optional(),
@@ -27,6 +28,7 @@ function parseFilters(query: any) {
 }
 
 @ApiTags('analytics')
+@UseGuards(ApiKeyGuard)
 @Controller('analytics')
 export class AnalyticsController {
   constructor(private service: AnalyticsService) {}

--- a/apps/api/src/api-key/api-key.controller.ts
+++ b/apps/api/src/api-key/api-key.controller.ts
@@ -1,0 +1,26 @@
+import { Body, Controller, Get, Param, Post, Query } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import { ApiKeyService } from './api-key.service';
+import { CreateApiKeyDto } from './dto';
+
+@ApiTags('api-keys')
+@Controller('api-keys')
+export class ApiKeyController {
+  constructor(private apiKeyService: ApiKeyService) {}
+
+  @Post()
+  create(@Body() dto: CreateApiKeyDto) {
+    const orgId = dto.orgId ?? 'default-org';
+    return this.apiKeyService.create(orgId, dto.scopes, dto.quota);
+  }
+
+  @Get()
+  list(@Query('orgId') orgId: string) {
+    return this.apiKeyService.list(orgId);
+  }
+
+  @Get(':id/usage')
+  usage(@Param('id') id: string) {
+    return this.apiKeyService.getUsage(id);
+  }
+}

--- a/apps/api/src/api-key/api-key.guard.ts
+++ b/apps/api/src/api-key/api-key.guard.ts
@@ -1,0 +1,27 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { ApiKeyService } from './api-key.service';
+
+@Injectable()
+export class ApiKeyGuard implements CanActivate {
+  constructor(private apiKeyService: ApiKeyService) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest();
+    const key = request.headers['x-api-key'];
+    if (!key) throw new UnauthorizedException('API key missing');
+    const record = await this.apiKeyService.validate(key);
+    if (!record) throw new UnauthorizedException('Invalid API key');
+    if (record.usage >= record.quota) {
+      throw new ForbiddenException('Quota exceeded');
+    }
+    await this.apiKeyService.incrementUsage(record.id);
+    request.orgId = record.orgId;
+    return true;
+  }
+}

--- a/apps/api/src/api-key/api-key.module.ts
+++ b/apps/api/src/api-key/api-key.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { ApiKeyService } from './api-key.service';
+import { ApiKeyController } from './api-key.controller';
+
+@Module({
+  providers: [ApiKeyService],
+  controllers: [ApiKeyController],
+  exports: [ApiKeyService],
+})
+export class ApiKeyModule {}

--- a/apps/api/src/api-key/api-key.service.ts
+++ b/apps/api/src/api-key/api-key.service.ts
@@ -1,0 +1,37 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma.service';
+import { randomBytes } from 'crypto';
+
+@Injectable()
+export class ApiKeyService {
+  constructor(private prisma: PrismaService) {}
+
+  async create(orgId: string, scopes: string[], quota: number) {
+    const key = randomBytes(32).toString('hex');
+    return this.prisma.apiKey.create({
+      data: { orgId, key, scopes, quota },
+    });
+  }
+
+  async validate(key: string) {
+    return this.prisma.apiKey.findUnique({ where: { key } });
+  }
+
+  async incrementUsage(id: string) {
+    return this.prisma.apiKey.update({
+      where: { id },
+      data: { usage: { increment: 1 }, lastUsedAt: new Date() },
+    });
+  }
+
+  async list(orgId: string) {
+    return this.prisma.apiKey.findMany({ where: { orgId } });
+  }
+
+  async getUsage(id: string) {
+    return this.prisma.apiKey.findUnique({
+      where: { id },
+      select: { usage: true, quota: true },
+    });
+  }
+}

--- a/apps/api/src/api-key/dto.ts
+++ b/apps/api/src/api-key/dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class CreateApiKeyDto {
+  @ApiProperty({ example: ['read', 'write'] })
+  scopes: string[];
+
+  @ApiProperty({ example: 1000 })
+  quota: number;
+
+  @ApiProperty({ example: 'org_123', required: false })
+  orgId?: string;
+}

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -1,6 +1,8 @@
 import { Module } from '@nestjs/common';
 import { ScheduleModule } from '@nestjs/schedule';
 import { BullModule } from '@nestjs/bull';
+import { ThrottlerModule, ThrottlerGuard } from '@nestjs/throttler';
+import { APP_GUARD } from '@nestjs/core';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { PrismaService } from './prisma.service';
@@ -80,10 +82,13 @@ import { AnalyticsService } from './analytics/analytics.service';
 import { MarketDataService } from './analytics/market-data.service';
 import { IntegrationModule } from './integration/integration.module';
 import { HealthModule } from './health/health.module';
+import { ApiKeyModule } from './api-key/api-key.module';
 
 @Module({
   imports: [
     AuthModule,
+    ApiKeyModule,
+    ThrottlerModule.forRoot({ ttl: 60, limit: 100 }),
     ScheduleModule.forRoot(),
     BullModule.forRoot({
       redis: {
@@ -173,6 +178,10 @@ import { HealthModule } from './health/health.module';
     {
       provide: SMART_METER_CONNECTOR,
       useClass: MockSmartMeterConnector,
+    },
+    {
+      provide: APP_GUARD,
+      useClass: ThrottlerGuard,
     },
   ],
 })

--- a/apps/web/app/usage/page.tsx
+++ b/apps/web/app/usage/page.tsx
@@ -1,0 +1,8 @@
+export default function UsagePage() {
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold">API Usage Metrics</h1>
+      <p>This page will display usage metrics and pricing counters for API keys.</p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- extend ApiKey model with scopes, quotas and usage tracking
- add API key service, controller and guard
- secure analytics endpoints and enable global rate limiting
- add placeholder usage metrics page

## Testing
- `npm test` (apps/api)
- `npm run lint` (apps/api) *(fails: ESLint couldn't find a config file)*
- `npm run build` (apps/api) *(fails: missing @nestjs/throttler dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68b42b1527e0832e82b5443eede91d36