### PR TITLE
feat: add referral tracking and disputes admin view

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -85,6 +85,10 @@ import { HealthModule } from './health/health.module';
 import { ApiKeyModule } from './api-key/api-key.module';
 import { OrgController } from './org/org.controller';
 import { OrgService } from './org/org.service';
+import { ReferralController } from './referral/referral.controller';
+import { ReferralService } from './referral/referral.service';
+import { DisputeController } from './dispute/dispute.controller';
+import { DisputeService } from './dispute/dispute.service';
 
 @Module({
   imports: [
@@ -124,6 +128,8 @@ import { OrgService } from './org/org.service';
     AssessmentController,
     UtilityReadingController,
     UtilityProviderController,
+    ReferralController,
+    DisputeController,
     AnalyticsController,
     OrgController,
   ],
@@ -176,6 +182,8 @@ import { OrgService } from './org/org.service';
     GreenScoreRepository,
     GreenService,
     UtilityProviderService,
+    ReferralService,
+    DisputeService,
     AnalyticsService,
     MarketDataService,
     OrgService,

--- a/apps/api/src/dispute/dispute.controller.ts
+++ b/apps/api/src/dispute/dispute.controller.ts
@@ -1,0 +1,12 @@
+import { Controller, Get } from '@nestjs/common';
+import { DisputeService } from './dispute.service';
+
+@Controller('disputes')
+export class DisputeController {
+  constructor(private readonly service: DisputeService) {}
+
+  @Get()
+  list() {
+    return this.service.list();
+  }
+}

--- a/apps/api/src/dispute/dispute.service.ts
+++ b/apps/api/src/dispute/dispute.service.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@nestjs/common';
+import { randomUUID } from 'crypto';
+import { Dispute } from '@tenancy/types';
+
+@Injectable()
+export class DisputeService {
+  private disputes: Dispute[] = [
+    {
+      id: randomUUID(),
+      claimant: 'Tenant A',
+      respondent: 'Landlord B',
+      issue: 'Late deposit',
+      status: 'open',
+      createdAt: new Date(),
+    },
+  ];
+
+  list(): Dispute[] {
+    return this.disputes;
+  }
+}

--- a/apps/api/src/referral/referral.controller.ts
+++ b/apps/api/src/referral/referral.controller.ts
@@ -1,0 +1,23 @@
+import { Controller, Post, Body, Get } from '@nestjs/common';
+import { ReferralService } from './referral.service';
+
+@Controller('referrals')
+export class ReferralController {
+  constructor(private readonly service: ReferralService) {}
+
+  @Post('generate')
+  generate(@Body('providerId') providerId: string) {
+    return this.service.generateLink(providerId);
+  }
+
+  @Post('track')
+  track(@Body('code') code: string) {
+    const result = this.service.trackReferral(code);
+    return result ?? { error: 'Invalid code' };
+  }
+
+  @Get('ledger')
+  ledger() {
+    return this.service.getLedger();
+  }
+}

--- a/apps/api/src/referral/referral.service.ts
+++ b/apps/api/src/referral/referral.service.ts
@@ -1,0 +1,56 @@
+import { Injectable } from '@nestjs/common';
+import { randomUUID } from 'crypto';
+import {
+  ReferralLink,
+  ReferralAttribution,
+  PayoutLedgerEntry,
+} from '@tenancy/types';
+import { UtilityProviderService } from '../utility-provider/utility-provider.service';
+
+@Injectable()
+export class ReferralService {
+  private links: ReferralLink[] = [];
+  private attributions: ReferralAttribution[] = [];
+  private ledger: PayoutLedgerEntry[] = [];
+
+  constructor(private readonly providerService: UtilityProviderService) {}
+
+  generateLink(providerId: string): ReferralLink {
+    const code = randomUUID().slice(0, 8);
+    const url = `${process.env.WEB_URL || 'http://localhost:3000'}/ref/${code}`;
+    const link: ReferralLink = { code, providerId, url };
+    this.links.push(link);
+    return link;
+  }
+
+  trackReferral(code: string): ReferralAttribution | undefined {
+    const link = this.links.find((l) => l.code === code);
+    if (!link) return undefined;
+    const provider = this.providerService
+      .listProviders()
+      .find((p) => p.id === link.providerId);
+    if (!provider) return undefined;
+    const commission = provider.estimatedSavings * 0.1;
+    const attribution: ReferralAttribution = {
+      id: randomUUID(),
+      providerId: link.providerId,
+      code: link.code,
+      commission,
+      createdAt: new Date(),
+    };
+    this.attributions.push(attribution);
+    const payout: PayoutLedgerEntry = {
+      id: randomUUID(),
+      referralId: attribution.id,
+      amount: commission,
+      paid: false,
+      createdAt: new Date(),
+    };
+    this.ledger.push(payout);
+    return attribution;
+  }
+
+  getLedger(): PayoutLedgerEntry[] {
+    return this.ledger;
+  }
+}

--- a/apps/web/app/admin/disputes/page.tsx
+++ b/apps/web/app/admin/disputes/page.tsx
@@ -1,0 +1,37 @@
+import { Dispute } from '@tenancy/types';
+
+const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001';
+
+async function getDisputes(): Promise<Dispute[]> {
+  const res = await fetch(`${apiUrl}/disputes`, { cache: 'no-store' });
+  return res.json();
+}
+
+export default async function AdminDisputesPage() {
+  const disputes = await getDisputes();
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-xl font-bold">Disputes</h1>
+      <table className="min-w-full border">
+        <thead>
+          <tr>
+            <th className="border px-2 py-1">Claimant</th>
+            <th className="border px-2 py-1">Respondent</th>
+            <th className="border px-2 py-1">Issue</th>
+            <th className="border px-2 py-1">Status</th>
+          </tr>
+        </thead>
+        <tbody>
+          {disputes.map((d) => (
+            <tr key={d.id}>
+              <td className="border px-2 py-1">{d.claimant}</td>
+              <td className="border px-2 py-1">{d.respondent}</td>
+              <td className="border px-2 py-1">{d.issue}</td>
+              <td className="border px-2 py-1">{d.status}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/apps/web/app/referrals/GenerateLinkForm.tsx
+++ b/apps/web/app/referrals/GenerateLinkForm.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { useState } from 'react';
+
+const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001';
+
+export function GenerateLinkForm() {
+  const [providerId, setProviderId] = useState('');
+  const [link, setLink] = useState<string | null>(null);
+
+  const generate = async () => {
+    const res = await fetch(`${apiUrl}/referrals/generate`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ providerId }),
+    });
+    const data = await res.json();
+    setLink(data.url);
+  };
+
+  return (
+    <div className="space-y-2">
+      <input
+        className="border p-1"
+        value={providerId}
+        onChange={(e) => setProviderId(e.target.value)}
+        placeholder="Provider ID"
+      />
+      <button className="border px-3 py-1" onClick={generate}>
+        Generate Link
+      </button>
+      {link && <div className="text-sm break-all">Link: {link}</div>}
+    </div>
+  );
+}

--- a/apps/web/app/referrals/TrackReferralForm.tsx
+++ b/apps/web/app/referrals/TrackReferralForm.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { useState } from 'react';
+
+const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001';
+
+export function TrackReferralForm() {
+  const [code, setCode] = useState('');
+  const [result, setResult] = useState<string | null>(null);
+
+  const track = async () => {
+    const res = await fetch(`${apiUrl}/referrals/track`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ code }),
+    });
+    const data = await res.json();
+    setResult(data.error ? data.error : 'Tracked');
+  };
+
+  return (
+    <div className="space-y-2">
+      <input
+        className="border p-1"
+        value={code}
+        onChange={(e) => setCode(e.target.value)}
+        placeholder="Referral Code"
+      />
+      <button className="border px-3 py-1" onClick={track}>
+        Track Referral
+      </button>
+      {result && <div className="text-sm">{result}</div>}
+    </div>
+  );
+}

--- a/apps/web/app/referrals/page.tsx
+++ b/apps/web/app/referrals/page.tsx
@@ -1,0 +1,40 @@
+import { PayoutLedgerEntry } from '@tenancy/types';
+import { GenerateLinkForm } from './GenerateLinkForm';
+import { TrackReferralForm } from './TrackReferralForm';
+
+const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001';
+
+async function getLedger(): Promise<PayoutLedgerEntry[]> {
+  const res = await fetch(`${apiUrl}/referrals/ledger`, { cache: 'no-store' });
+  return res.json();
+}
+
+export default async function ReferralsPage() {
+  const ledger = await getLedger();
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-xl font-bold">Referrals</h1>
+      <GenerateLinkForm />
+      <TrackReferralForm />
+      <h2 className="text-lg font-semibold pt-4">Payout Ledger</h2>
+      <table className="min-w-full border">
+        <thead>
+          <tr>
+            <th className="border px-2 py-1">Referral</th>
+            <th className="border px-2 py-1">Amount</th>
+            <th className="border px-2 py-1">Paid</th>
+          </tr>
+        </thead>
+        <tbody>
+          {ledger.map((entry) => (
+            <tr key={entry.id}>
+              <td className="border px-2 py-1">{entry.referralId}</td>
+              <td className="border px-2 py-1">${entry.amount.toFixed(2)}</td>
+              <td className="border px-2 py-1">{entry.paid ? 'Yes' : 'No'}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -148,3 +148,34 @@ export interface OrganizationTheme {
   emailTemplate?: string;
 }
 
+export interface ReferralLink {
+  code: string;
+  providerId: string;
+  url: string;
+}
+
+export interface ReferralAttribution {
+  id: string;
+  providerId: string;
+  code: string;
+  commission: number;
+  createdAt: Date;
+}
+
+export interface PayoutLedgerEntry {
+  id: string;
+  referralId: string;
+  amount: number;
+  paid: boolean;
+  createdAt: Date;
+}
+
+export interface Dispute {
+  id: string;
+  claimant: string;
+  respondent: string;
+  issue: string;
+  status: 'open' | 'resolved';
+  createdAt: Date;
+}
+


### PR DESCRIPTION
## Summary
- add referral link generation and commission ledger
- expose disputes for admin review

## Testing
- `npm install` (fails: Unsupported URL Type "workspace:")
- `npm run lint` (fails: turbo: not found)
- `npm run typecheck` (fails: turbo: not found)


------
https://chatgpt.com/codex/tasks/task_e_68b42fa54794832eb529733498bf96c0