### PR TITLE
feat: add notification preferences with web push support

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -36,7 +36,8 @@
     "bull": "^4.10.4",
     "ics": "^2.41.0",
     "nodemailer": "^6.9.8",
-    "twilio": "^4.11.0"
+    "twilio": "^4.11.0",
+    "web-push": "^3.5.2"
   },
   "devDependencies": {
     "@types/passport-google-oauth20": "^2.0.11",

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -82,6 +82,8 @@ model User {
   auditLogs     AuditLog[]     @relation("ActorLogs")
   accounts      Account[]
   sessions      Session[]
+  notificationPreferences NotificationPreference[]
+  pushSubscriptions PushSubscription[]
 }
 
 model Account {
@@ -552,8 +554,44 @@ model Notification {
   user      User         @relation(fields: [userId], references: [id])
   userId    String
   message   String
+  event     String
   read      Boolean      @default(false)
   createdAt DateTime     @default(now())
+}
+
+enum NotificationFrequency {
+  instant
+  daily
+  weekly
+}
+
+model NotificationPreference {
+  id        String   @id @default(cuid())
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId    String
+  event     String
+  email     Boolean @default(true)
+  sms       Boolean @default(false)
+  whatsapp  Boolean @default(false)
+  push      Boolean @default(true)
+  frequency NotificationFrequency @default(instant)
+  quietStart String?
+  quietEnd   String?
+  createdAt DateTime @default(now())
+
+  @@unique([userId, event])
+}
+
+model PushSubscription {
+  id        String   @id @default(cuid())
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId    String
+  endpoint  String
+  p256dh    String
+  auth      String
+  createdAt DateTime @default(now())
+
+  @@unique([userId, endpoint])
 }
 
 model ApiKey {

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -89,6 +89,10 @@ import { ReferralController } from './referral/referral.controller';
 import { ReferralService } from './referral/referral.service';
 import { DisputeController } from './dispute/dispute.controller';
 import { DisputeService } from './dispute/dispute.service';
+import { NotificationController } from './notification/notification.controller';
+import { NotificationService } from './notification/notification.service';
+import { NotificationRepository } from './notification/notification.repository';
+import { WebPushService } from './notification/web-push.service';
 
 @Module({
   imports: [
@@ -132,6 +136,7 @@ import { DisputeService } from './dispute/dispute.service';
     DisputeController,
     AnalyticsController,
     OrgController,
+    NotificationController,
   ],
   providers: [
     AppService,
@@ -187,6 +192,9 @@ import { DisputeService } from './dispute/dispute.service';
     AnalyticsService,
     MarketDataService,
     OrgService,
+    NotificationRepository,
+    NotificationService,
+    WebPushService,
     {
       provide: SMART_METER_CONNECTOR,
       useClass: MockSmartMeterConnector,

--- a/apps/api/src/notification/notification.controller.ts
+++ b/apps/api/src/notification/notification.controller.ts
@@ -1,0 +1,36 @@
+import { Body, Controller, Get, Param, Patch, Post } from '@nestjs/common';
+import { NotificationService } from './notification.service';
+
+@Controller('notifications')
+export class NotificationController {
+  constructor(private readonly service: NotificationService) {}
+
+  @Get(':userId')
+  inbox(@Param('userId') userId: string) {
+    return this.service.getInbox(userId);
+  }
+
+  @Post()
+  create(@Body() body: any) {
+    return this.service.create(body);
+  }
+
+  @Patch(':id/read')
+  markRead(@Param('id') id: string) {
+    return this.service.markRead(id);
+  }
+
+  @Post('preferences/:userId/:event')
+  setPref(
+    @Param('userId') userId: string,
+    @Param('event') event: string,
+    @Body() body: any
+  ) {
+    return this.service.setPreference(userId, event, body);
+  }
+
+  @Post('push-subscription/:userId')
+  subscribe(@Param('userId') userId: string, @Body() body: any) {
+    return this.service.registerSubscription(userId, body);
+  }
+}

--- a/apps/api/src/notification/notification.repository.ts
+++ b/apps/api/src/notification/notification.repository.ts
@@ -1,0 +1,59 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma.service';
+
+@Injectable()
+export class NotificationRepository {
+  constructor(private prisma: PrismaService) {}
+
+  createNotification(data: any) {
+    return this.prisma.notification.create({ data });
+  }
+
+  findNotifications(userId: string) {
+    return this.prisma.notification.findMany({
+      where: { userId },
+      orderBy: { createdAt: 'desc' },
+    });
+  }
+
+  markRead(id: string) {
+    return this.prisma.notification.update({
+      where: { id },
+      data: { read: true },
+    });
+  }
+
+  upsertPreference(data: any) {
+    return this.prisma.notificationPreference.upsert({
+      where: { userId_event: { userId: data.userId, event: data.event } },
+      update: data,
+      create: data,
+    });
+  }
+
+  findPreference(userId: string, event: string) {
+    return this.prisma.notificationPreference.findUnique({
+      where: { userId_event: { userId, event } },
+    });
+  }
+
+  upsertSubscription(
+    userId: string,
+    sub: { endpoint: string; keys: { p256dh: string; auth: string } }
+  ) {
+    return this.prisma.pushSubscription.upsert({
+      where: { userId_endpoint: { userId, endpoint: sub.endpoint } },
+      update: { p256dh: sub.keys.p256dh, auth: sub.keys.auth },
+      create: {
+        userId,
+        endpoint: sub.endpoint,
+        p256dh: sub.keys.p256dh,
+        auth: sub.keys.auth,
+      },
+    });
+  }
+
+  findSubscriptions(userId: string) {
+    return this.prisma.pushSubscription.findMany({ where: { userId } });
+  }
+}

--- a/apps/api/src/notification/notification.service.ts
+++ b/apps/api/src/notification/notification.service.ts
@@ -1,0 +1,72 @@
+import { Injectable } from '@nestjs/common';
+import { NotificationRepository } from './notification.repository';
+import { WebPushService } from './web-push.service';
+
+@Injectable()
+export class NotificationService {
+  constructor(
+    private readonly repo: NotificationRepository,
+    private readonly push: WebPushService
+  ) {}
+
+  getInbox(userId: string) {
+    return this.repo.findNotifications(userId);
+  }
+
+  markRead(id: string) {
+    return this.repo.markRead(id);
+  }
+
+  async create(data: {
+    orgId: string;
+    userId: string;
+    event: string;
+    message: string;
+  }) {
+    const notification = await this.repo.createNotification(data);
+    const pref = await this.repo.findPreference(data.userId, data.event);
+    if (pref?.push && !this.inQuietHours(pref)) {
+      await this.push.send(data.userId, {
+        title: data.event,
+        body: data.message,
+      });
+    }
+    return notification;
+  }
+
+  setPreference(
+    userId: string,
+    event: string,
+    pref: {
+      email?: boolean;
+      sms?: boolean;
+      whatsapp?: boolean;
+      push?: boolean;
+      frequency?: string;
+      quietStart?: string | null;
+      quietEnd?: string | null;
+    }
+  ) {
+    return this.repo.upsertPreference({ userId, event, ...pref });
+  }
+
+  registerSubscription(userId: string, sub: any) {
+    return this.repo.upsertSubscription(userId, sub);
+  }
+
+  private inQuietHours(pref: {
+    quietStart?: string | null;
+    quietEnd?: string | null;
+  }) {
+    if (!pref.quietStart || !pref.quietEnd) return false;
+    const now = new Date();
+    const [sH, sM] = pref.quietStart.split(':').map(Number);
+    const [eH, eM] = pref.quietEnd.split(':').map(Number);
+    const start = new Date();
+    start.setHours(sH, sM, 0, 0);
+    const end = new Date();
+    end.setHours(eH, eM, 0, 0);
+    if (start <= end) return now >= start && now <= end;
+    return now >= start || now <= end;
+  }
+}

--- a/apps/api/src/notification/web-push.d.ts
+++ b/apps/api/src/notification/web-push.d.ts
@@ -1,0 +1,4 @@
+declare module 'web-push' {
+  const value: any;
+  export default value;
+}

--- a/apps/api/src/notification/web-push.service.ts
+++ b/apps/api/src/notification/web-push.service.ts
@@ -1,0 +1,31 @@
+import { Injectable } from '@nestjs/common';
+import webpush from 'web-push';
+import { NotificationRepository } from './notification.repository';
+
+@Injectable()
+export class WebPushService {
+  constructor(private readonly repo: NotificationRepository) {
+    if (process.env.VAPID_PUBLIC_KEY && process.env.VAPID_PRIVATE_KEY) {
+      webpush.setVapidDetails(
+        'mailto:example@example.com',
+        process.env.VAPID_PUBLIC_KEY,
+        process.env.VAPID_PRIVATE_KEY
+      );
+    }
+  }
+
+  async send(userId: string, payload: any) {
+    const subs = await this.repo.findSubscriptions(userId);
+    const message = JSON.stringify(payload);
+    await Promise.all(
+      subs.map((s) =>
+        webpush
+          .sendNotification(
+            { endpoint: s.endpoint, keys: { auth: s.auth, p256dh: s.p256dh } },
+            message
+          )
+          .catch(() => undefined)
+      )
+    );
+  }
+}

--- a/apps/web/app/notifications/PreferenceForm.tsx
+++ b/apps/web/app/notifications/PreferenceForm.tsx
@@ -1,0 +1,106 @@
+'use client';
+
+import { useState } from 'react';
+
+export default function PreferenceForm() {
+  const [event, setEvent] = useState('general');
+  const [prefs, setPrefs] = useState({
+    email: true,
+    sms: false,
+    whatsapp: false,
+    push: true,
+    frequency: 'instant',
+    quietStart: '',
+    quietEnd: '',
+  });
+
+  const submit = async () => {
+    await fetch(`/api/notifications/preferences/me/${event}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(prefs),
+    });
+  };
+
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        submit();
+      }}
+      className="space-y-2"
+    >
+      <div>
+        <label className="mr-2">Event</label>
+        <input
+          value={event}
+          onChange={(e) => setEvent(e.target.value)}
+          className="border p-1"
+        />
+      </div>
+      <div className="flex gap-2">
+        <label>
+          <input
+            type="checkbox"
+            checked={prefs.email}
+            onChange={(e) => setPrefs({ ...prefs, email: e.target.checked })}
+          />
+          Email
+        </label>
+        <label>
+          <input
+            type="checkbox"
+            checked={prefs.sms}
+            onChange={(e) => setPrefs({ ...prefs, sms: e.target.checked })}
+          />
+          SMS
+        </label>
+        <label>
+          <input
+            type="checkbox"
+            checked={prefs.whatsapp}
+            onChange={(e) => setPrefs({ ...prefs, whatsapp: e.target.checked })}
+          />
+          WhatsApp
+        </label>
+        <label>
+          <input
+            type="checkbox"
+            checked={prefs.push}
+            onChange={(e) => setPrefs({ ...prefs, push: e.target.checked })}
+          />
+          Push
+        </label>
+      </div>
+      <div>
+        <label className="mr-2">Frequency</label>
+        <select
+          value={prefs.frequency}
+          onChange={(e) => setPrefs({ ...prefs, frequency: e.target.value })}
+          className="border p-1"
+        >
+          <option value="instant">Instant</option>
+          <option value="daily">Daily</option>
+          <option value="weekly">Weekly</option>
+        </select>
+      </div>
+      <div className="flex gap-2">
+        <input
+          type="time"
+          value={prefs.quietStart}
+          onChange={(e) => setPrefs({ ...prefs, quietStart: e.target.value })}
+          className="border p-1"
+        />
+        <input
+          type="time"
+          value={prefs.quietEnd}
+          onChange={(e) => setPrefs({ ...prefs, quietEnd: e.target.value })}
+          className="border p-1"
+        />
+      </div>
+      <button type="submit" className="px-2 py-1 bg-blue-500 text-white">
+        Save
+      </button>
+    </form>
+  );
+}

--- a/apps/web/app/notifications/PushSubscriber.tsx
+++ b/apps/web/app/notifications/PushSubscriber.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { useEffect } from 'react';
+
+function urlBase64ToUint8Array(base64String: string) {
+  const padding = '='.repeat((4 - (base64String.length % 4)) % 4);
+  const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/');
+  const rawData = atob(base64);
+  return Uint8Array.from([...rawData].map((char) => char.charCodeAt(0)));
+}
+
+export default function PushSubscriber() {
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    if (!('serviceWorker' in navigator) || !('PushManager' in window)) return;
+    navigator.serviceWorker.ready.then(async (reg) => {
+      const publicKey = process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY;
+      if (!publicKey) return;
+      const existing = await reg.pushManager.getSubscription();
+      if (existing) return;
+      const permission = await Notification.requestPermission();
+      if (permission !== 'granted') return;
+      const sub = await reg.pushManager.subscribe({
+        userVisibleOnly: true,
+        applicationServerKey: urlBase64ToUint8Array(publicKey),
+      });
+      await fetch('/api/notifications/push-subscription/me', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(sub),
+      });
+    });
+  }, []);
+  return null;
+}

--- a/apps/web/app/notifications/page.tsx
+++ b/apps/web/app/notifications/page.tsx
@@ -1,0 +1,26 @@
+import PushSubscriber from './PushSubscriber';
+import PreferenceForm from './PreferenceForm';
+
+async function getNotifications() {
+  const res = await fetch('http://localhost:3001/notifications/me', {
+    cache: 'no-store',
+  });
+  if (!res.ok) return [];
+  return res.json();
+}
+
+export default async function NotificationsPage() {
+  const notifications = await getNotifications();
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-xl font-bold">Notifications</h1>
+      <PushSubscriber />
+      <ul className="list-disc pl-5">
+        {notifications.map((n: any) => (
+          <li key={n.id}>{n.message}</li>
+        ))}
+      </ul>
+      <PreferenceForm />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- extend Prisma schema with notification preferences and push subscriptions
- add backend services/controllers for unified inbox and web push
- create frontend inbox with push subscription and preference form

## Testing
- `npm test` (fails: Missing script)
- `npm --workspace apps/api test`


------
https://chatgpt.com/codex/tasks/task_e_68b43590b840832e9e68029adcd33948