### PR TITLE
feat: add security and audit features

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -93,6 +93,13 @@ import { NotificationController } from './notification/notification.controller';
 import { NotificationService } from './notification/notification.service';
 import { NotificationRepository } from './notification/notification.repository';
 import { WebPushService } from './notification/web-push.service';
+import { SessionController } from './session/session.controller';
+import { SessionService } from './session/session.service';
+import { UserController } from './user/user.controller';
+import { UserService } from './user/user.service';
+import { AuditLogController } from './audit-log/audit-log.controller';
+import { AuditLogService } from './audit-log/audit-log.service';
+import { MfaGuard } from './auth/guards/mfa.guard';
 
 @Module({
   imports: [
@@ -137,6 +144,9 @@ import { WebPushService } from './notification/web-push.service';
     AnalyticsController,
     OrgController,
     NotificationController,
+    SessionController,
+    UserController,
+    AuditLogController,
   ],
   providers: [
     AppService,
@@ -203,6 +213,13 @@ import { WebPushService } from './notification/web-push.service';
       provide: APP_GUARD,
       useClass: ThrottlerGuard,
     },
+    {
+      provide: APP_GUARD,
+      useClass: MfaGuard,
+    },
+    SessionService,
+    UserService,
+    AuditLogService,
   ],
 })
 export class AppModule {}

--- a/apps/api/src/audit-log/audit-log.controller.ts
+++ b/apps/api/src/audit-log/audit-log.controller.ts
@@ -1,0 +1,16 @@
+import { Controller, Get, Query } from '@nestjs/common';
+import { AuditLogService } from './audit-log.service';
+
+@Controller('audit-logs')
+export class AuditLogController {
+  constructor(private readonly service: AuditLogService) {}
+
+  @Get()
+  list(
+    @Query('orgId') orgId?: string,
+    @Query('actorId') actorId?: string,
+    @Query('action') action?: string
+  ) {
+    return this.service.list({ orgId, actorId, action });
+  }
+}

--- a/apps/api/src/audit-log/audit-log.service.ts
+++ b/apps/api/src/audit-log/audit-log.service.ts
@@ -1,0 +1,14 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma.service';
+
+@Injectable()
+export class AuditLogService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  list(filter: { orgId?: string; actorId?: string; action?: string }) {
+    return this.prisma.auditLog.findMany({
+      where: filter,
+      orderBy: { createdAt: 'desc' },
+    });
+  }
+}

--- a/apps/api/src/auth/guards/mfa.guard.ts
+++ b/apps/api/src/auth/guards/mfa.guard.ts
@@ -1,0 +1,24 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  ForbiddenException,
+} from '@nestjs/common';
+import { Request } from 'express';
+
+@Injectable()
+export class MfaGuard implements CanActivate {
+  canActivate(context: ExecutionContext): boolean {
+    const req = context.switchToHttp().getRequest<Request & { user?: any }>();
+    // Skip MFA for auth routes
+    if (req.path.startsWith('/auth')) {
+      return true;
+    }
+    const user = req.user;
+    // If user has MFA enabled, require x-mfa-verified header
+    if (user?.totpEnabled && req.headers['x-mfa-verified'] !== 'true') {
+      throw new ForbiddenException('MFA required');
+    }
+    return true;
+  }
+}

--- a/apps/api/src/ip-filter.middleware.ts
+++ b/apps/api/src/ip-filter.middleware.ts
@@ -1,0 +1,30 @@
+import { Injectable, NestMiddleware } from '@nestjs/common';
+import { Request, Response, NextFunction } from 'express';
+
+@Injectable()
+export class IpFilterMiddleware implements NestMiddleware {
+  private allow: string[];
+  private deny: string[];
+
+  constructor() {
+    this.allow =
+      process.env.IP_ALLOW_LIST?.split(',')
+        .map((s) => s.trim())
+        .filter(Boolean) || [];
+    this.deny =
+      process.env.IP_DENY_LIST?.split(',')
+        .map((s) => s.trim())
+        .filter(Boolean) || [];
+  }
+
+  use(req: Request, res: Response, next: NextFunction) {
+    const ip = req.ip;
+    if (this.deny.includes(ip)) {
+      return res.status(403).send('Forbidden');
+    }
+    if (this.allow.length && !this.allow.includes(ip)) {
+      return res.status(403).send('Forbidden');
+    }
+    next();
+  }
+}

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -1,11 +1,16 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
+import { IpFilterMiddleware } from './ip-filter.middleware';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+  app.use(new IpFilterMiddleware().use);
 
-  const config = new DocumentBuilder().setTitle('API').setVersion('1.0').build();
+  const config = new DocumentBuilder()
+    .setTitle('API')
+    .setVersion('1.0')
+    .build();
   const document = SwaggerModule.createDocument(app, config);
   SwaggerModule.setup('docs', app, document);
 

--- a/apps/api/src/session/session.controller.ts
+++ b/apps/api/src/session/session.controller.ts
@@ -1,0 +1,17 @@
+import { Controller, Get, Delete, Param } from '@nestjs/common';
+import { SessionService } from './session.service';
+
+@Controller('sessions')
+export class SessionController {
+  constructor(private readonly service: SessionService) {}
+
+  @Get()
+  list() {
+    return this.service.list();
+  }
+
+  @Delete(':id')
+  revoke(@Param('id') id: string) {
+    return this.service.revoke(id);
+  }
+}

--- a/apps/api/src/session/session.service.ts
+++ b/apps/api/src/session/session.service.ts
@@ -1,0 +1,27 @@
+import { Inject, Injectable, Scope } from '@nestjs/common';
+import { REQUEST } from '@nestjs/core';
+import { Request } from 'express';
+import { PrismaService } from '../prisma.service';
+
+@Injectable({ scope: Scope.REQUEST })
+export class SessionService {
+  constructor(
+    private readonly prisma: PrismaService,
+    @Inject(REQUEST) private readonly request: Request
+  ) {}
+
+  list() {
+    const userId = (this.request as any).user?.id;
+    return this.prisma.session.findMany({ where: { userId } });
+  }
+
+  async revoke(id: string) {
+    const userId = (this.request as any).user?.id;
+    const orgId = (this.request as any).orgId;
+    await this.prisma.session.delete({ where: { id } });
+    await this.prisma.auditLog.create({
+      data: { orgId, actorId: userId, action: 'revoke_session', target: id },
+    });
+    return { status: 'revoked' };
+  }
+}

--- a/apps/api/src/user/user.controller.ts
+++ b/apps/api/src/user/user.controller.ts
@@ -1,0 +1,17 @@
+import { Controller, Get, Post } from '@nestjs/common';
+import { UserService } from './user.service';
+
+@Controller('user')
+export class UserController {
+  constructor(private readonly service: UserService) {}
+
+  @Get('export')
+  export() {
+    return this.service.export();
+  }
+
+  @Post('anonymize')
+  anonymize() {
+    return this.service.anonymize();
+  }
+}

--- a/apps/api/src/user/user.service.ts
+++ b/apps/api/src/user/user.service.ts
@@ -1,0 +1,35 @@
+import { Inject, Injectable, Scope } from '@nestjs/common';
+import { REQUEST } from '@nestjs/core';
+import { Request } from 'express';
+import { PrismaService } from '../prisma.service';
+
+@Injectable({ scope: Scope.REQUEST })
+export class UserService {
+  constructor(
+    private readonly prisma: PrismaService,
+    @Inject(REQUEST) private readonly request: Request
+  ) {}
+
+  export() {
+    const userId = (this.request as any).user?.id;
+    return this.prisma.user.findUnique({ where: { id: userId } });
+  }
+
+  async anonymize() {
+    const userId = (this.request as any).user?.id;
+    const orgId = (this.request as any).orgId;
+    await this.prisma.user.update({
+      where: { id: userId },
+      data: { email: null, name: null, totpSecret: null, image: null },
+    });
+    await this.prisma.auditLog.create({
+      data: {
+        orgId,
+        actorId: userId,
+        action: 'anonymize_user',
+        target: userId,
+      },
+    });
+    return { status: 'anonymized' };
+  }
+}

--- a/apps/web/app/audit-logs/page.tsx
+++ b/apps/web/app/audit-logs/page.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+
+type AuditLog = {
+  id: string;
+  actorId?: string;
+  action: string;
+  target?: string;
+  createdAt: string;
+};
+
+async function fetchLogs(
+  searchParams: Record<string, string | undefined>
+): Promise<AuditLog[]> {
+  const query = new URLSearchParams(searchParams as Record<string, string>);
+  const res = await fetch(
+    `${process.env.NEXT_PUBLIC_API_URL}/audit-logs?${query.toString()}`,
+    {
+      cache: 'no-store',
+    }
+  );
+  if (!res.ok) return [];
+  return res.json();
+}
+
+export default async function AuditLogsPage({
+  searchParams,
+}: {
+  searchParams: Record<string, string | undefined>;
+}) {
+  const logs = await fetchLogs(searchParams);
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-semibold mb-4">Audit Logs</h1>
+      <form className="mb-4">
+        <input
+          className="border p-1 mr-2"
+          type="text"
+          name="actorId"
+          placeholder="Actor ID"
+          defaultValue={searchParams.actorId}
+        />
+        <input
+          className="border p-1 mr-2"
+          type="text"
+          name="action"
+          placeholder="Action"
+          defaultValue={searchParams.action}
+        />
+        <button className="border px-2" type="submit">
+          Filter
+        </button>
+      </form>
+      <table className="w-full text-left border">
+        <thead>
+          <tr>
+            <th className="border p-1">Time</th>
+            <th className="border p-1">Actor</th>
+            <th className="border p-1">Action</th>
+            <th className="border p-1">Target</th>
+          </tr>
+        </thead>
+        <tbody>
+          {logs.map((l) => (
+            <tr key={l.id}>
+              <td className="border p-1">
+                {new Date(l.createdAt).toLocaleString()}
+              </td>
+              <td className="border p-1">{l.actorId || '-'}</td>
+              <td className="border p-1">{l.action}</td>
+              <td className="border p-1">{l.target || '-'}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- enforce multi-factor authentication and IP filtering for requests
- add session management, GDPR export and anonymization endpoints
- introduce audit log API and viewer page

## Testing
- `npm test`
- `npx --yes turbo lint` *(fails: Could not resolve workspaces, missing packageManager field)*
- `npm run build` (apps/web) *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b43aa9d7a4832e969f1aed676fe71a