### PR TITLE
feat(pwa): add offline support and background sync

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,6 +1,7 @@
 import '../i18n';
 import './globals.css';
 import type { ReactNode, CSSProperties } from 'react';
+import BackgroundSync from '../components/BackgroundSync';
 
 async function getTheme() {
   const orgId = process.env.NEXT_PUBLIC_ORG_ID;
@@ -28,6 +29,7 @@ export default async function RootLayout({ children }: { children: ReactNode }) 
           fontFamily: 'var(--brand-font)',
         }}
       >
+        <BackgroundSync />
         {children}
       </body>
     </html>

--- a/apps/web/app/leases/offline/page.tsx
+++ b/apps/web/app/leases/offline/page.tsx
@@ -1,0 +1,9 @@
+'use client';
+export default function LeasesOffline() {
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold">Leases Offline</h1>
+      <p>Lease data cannot be loaded while offline. Reconnect to synchronize the latest information.</p>
+    </div>
+  );
+}

--- a/apps/web/app/payments/offline/page.tsx
+++ b/apps/web/app/payments/offline/page.tsx
@@ -1,0 +1,9 @@
+'use client';
+export default function PaymentsOffline() {
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold">Payments Offline</h1>
+      <p>Payment features are unavailable while offline. Any actions will be queued and processed once reconnected.</p>
+    </div>
+  );
+}

--- a/apps/web/app/tickets/offline/page.tsx
+++ b/apps/web/app/tickets/offline/page.tsx
@@ -1,0 +1,9 @@
+'use client';
+export default function TicketsOffline() {
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold">Tickets Offline</h1>
+      <p>Ticket information is unavailable while offline. Please reconnect to load the latest data.</p>
+    </div>
+  );
+}

--- a/apps/web/components/BackgroundSync.tsx
+++ b/apps/web/components/BackgroundSync.tsx
@@ -1,0 +1,10 @@
+'use client';
+import { useEffect } from 'react';
+import { initEsignQueue } from '../lib/offlineQueue';
+
+export default function BackgroundSync() {
+  useEffect(() => {
+    initEsignQueue();
+  }, []);
+  return null;
+}

--- a/apps/web/lib/offlineQueue.ts
+++ b/apps/web/lib/offlineQueue.ts
@@ -1,0 +1,49 @@
+'use client';
+
+export interface QueueItem {
+  id: string;
+  payload: any;
+  version: number;
+}
+
+const STORAGE_KEY = 'esignQueue';
+
+export function enqueueEsign(item: QueueItem) {
+  const raw = localStorage.getItem(STORAGE_KEY);
+  const queue: QueueItem[] = raw ? JSON.parse(raw) : [];
+  queue.push(item);
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(queue));
+}
+
+export async function processEsignQueue() {
+  const raw = localStorage.getItem(STORAGE_KEY);
+  const queue: QueueItem[] = raw ? JSON.parse(raw) : [];
+  const remaining: QueueItem[] = [];
+  for (const item of queue) {
+    try {
+      const res = await fetch('/api/esign', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(item),
+      });
+      if (res.status === 409) {
+        const server = await res.json();
+        if (server.version && server.version > item.version) {
+          console.warn('Conflict detected for e-sign item', item.id);
+          continue; // drop local version and keep server version
+        }
+        throw new Error('Conflict unresolved');
+      }
+      if (!res.ok) throw new Error('Network error');
+    } catch (e) {
+      remaining.push(item);
+    }
+  }
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(remaining));
+}
+
+export function initEsignQueue() {
+  if (typeof window === 'undefined') return;
+  window.addEventListener('online', processEsignQueue);
+  processEsignQueue();
+}

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -10,4 +10,63 @@ const nextConfig = {
 
 export default withPWA({
   dest: 'public',
+  register: true,
+  skipWaiting: true,
+  runtimeCaching: [
+    {
+      urlPattern: /\/api\/tickets/,
+      handler: 'NetworkFirst',
+      options: {
+        cacheName: 'tickets-cache',
+        backgroundSync: {
+          name: 'tickets-queue',
+          options: {
+            maxRetentionTime: 24 * 60,
+          },
+        },
+      },
+    },
+    {
+      urlPattern: /\/api\/payments/,
+      handler: 'NetworkFirst',
+      options: {
+        cacheName: 'payments-cache',
+        backgroundSync: {
+          name: 'payments-queue',
+          options: {
+            maxRetentionTime: 24 * 60,
+          },
+        },
+      },
+    },
+    {
+      urlPattern: /\/api\/leases/,
+      handler: 'NetworkFirst',
+      options: {
+        cacheName: 'leases-cache',
+        backgroundSync: {
+          name: 'leases-queue',
+          options: {
+            maxRetentionTime: 24 * 60,
+          },
+        },
+      },
+    },
+    {
+      urlPattern: /\/api\/esign/,
+      handler: 'NetworkOnly',
+      method: 'POST',
+      options: {
+        backgroundSync: {
+          name: 'esign-queue',
+          options: {
+            maxRetentionTime: 24 * 60,
+          },
+        },
+      },
+    },
+  ],
+  fallbacks: {
+    document: '/offline.html',
+  },
 })(nextConfig);

--- a/apps/web/public/manifest.json
+++ b/apps/web/public/manifest.json
@@ -5,5 +5,16 @@
   "display": "standalone",
   "background_color": "#ffffff",
   "description": "PWA for Tenancy web app",
-  "icons": []
+  "icons": [
+    {
+      "src": "/icon-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/icon-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ]
 }

--- a/apps/web/public/offline.html
+++ b/apps/web/public/offline.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Offline</title>
+</head>
+<body>
+  <h1>You are offline</h1>
+  <p>The application is currently offline. You can still view cached content for tickets, payments, and leases.</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- configure service worker with offline fallbacks, caching and background sync
- add offline pages and e-sign queue with conflict resolution
- remove placeholder PWA icons so custom assets can be supplied later

## Testing
- `npm run lint` *(fails: turbo not found)*
- `npm run typecheck` *(fails: turbo not found)*
- `npm test` *(fails: Missing script "test")*
- `npm install` *(fails: Unsupported URL Type "workspace:")*

------
https://chatgpt.com/codex/tasks/task_e_68b440c54220832eab5d6d44e9573688