### PR TITLE
feat: implement certificate reminders and auth emails

### DIFF
--- a/apps/api/src/certificate/certificate.scheduler.ts
+++ b/apps/api/src/certificate/certificate.scheduler.ts
@@ -1,28 +1,48 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import { CertificateService } from './certificate.service';
+import { NotificationService } from '../notification/notification.service';
+import { PrismaService } from '../prisma.service';
 
 @Injectable()
 export class CertificateReminderService {
   private readonly logger = new Logger(CertificateReminderService.name);
-  constructor(private readonly certificates: CertificateService) {}
+  constructor(
+    private readonly certificates: CertificateService,
+    private readonly notifications: NotificationService,
+    private readonly prisma: PrismaService,
+  ) {}
 
   @Cron(CronExpression.EVERY_DAY_AT_1AM)
   async handleCron() {
     const now = new Date();
     for (const days of [30, 7, 1]) {
       const upcoming = await this.certificates.expiringWithin(days);
-      upcoming.forEach((c) => {
+      for (const c of upcoming) {
         const diff = Math.ceil(
           (c.expiryDate.getTime() - now.getTime()) / (1000 * 60 * 60 * 24),
         );
         if (diff === days) {
-          // TODO: Send email/SMS/WhatsApp reminder
+          const members = await this.prisma.membership.findMany({
+            where: { orgId: c.orgId },
+          });
+          await Promise.all(
+            members.map((m) =>
+              this.notifications.create({
+                orgId: c.orgId,
+                userId: m.userId,
+                event: 'certificate.expiry',
+                message: `Certificate ${c.type} for ${
+                  c.property?.name || c.unit?.name || 'unknown'
+                } expires in ${diff} days`,
+              }),
+            ),
+          );
           this.logger.log(
             `Certificate ${c.id} expiring in ${diff} days`,
           );
         }
-      });
+      }
     }
   }
 }

--- a/apps/web/app/api/auth/reset-password/route.ts
+++ b/apps/web/app/api/auth/reset-password/route.ts
@@ -1,6 +1,40 @@
 import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { randomUUID } from 'crypto';
 
 export async function POST(req: Request) {
-  // TODO: implement password reset email
+  const { email } = await req.json();
+  if (!email) {
+    return NextResponse.json({ error: 'Email required' }, { status: 400 });
+  }
+  const user = await prisma.user.findUnique({ where: { email } });
+  if (user) {
+    const token = randomUUID();
+    await prisma.verificationToken.create({
+      data: {
+        identifier: email,
+        token,
+        expires: new Date(Date.now() + 1000 * 60 * 60),
+      },
+    });
+    try {
+      const url = process.env.EMAIL_WEBHOOK_URL;
+      if (url) {
+        await fetch(url, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            to: email,
+            subject: 'Reset your password',
+            body: `Use this token to reset your password: ${token}`,
+          }),
+        });
+      } else {
+        console.log('Password reset token for', email, token);
+      }
+    } catch (e) {
+      console.error('Failed to send password reset email', e);
+    }
+  }
   return NextResponse.json({ ok: true });
 }

--- a/apps/web/app/api/auth/signup/route.ts
+++ b/apps/web/app/api/auth/signup/route.ts
@@ -1,6 +1,7 @@
 import { prisma } from '@/lib/prisma';
 import { hash } from 'bcryptjs';
 import { NextResponse } from 'next/server';
+import { randomUUID } from 'crypto';
 
 export async function POST(req: Request) {
   const { email, password } = await req.json();
@@ -13,6 +14,31 @@ export async function POST(req: Request) {
   }
   const hashed = await hash(password, 10);
   const user = await prisma.user.create({ data: { email, password: hashed } });
-  // TODO: send verification email
+  const token = randomUUID();
+  await prisma.verificationToken.create({
+    data: {
+      identifier: email,
+      token,
+      expires: new Date(Date.now() + 1000 * 60 * 60 * 24),
+    },
+  });
+  try {
+    const url = process.env.EMAIL_WEBHOOK_URL;
+    if (url) {
+      await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          to: email,
+          subject: 'Verify your email',
+          body: `Use this token to verify your email: ${token}`,
+        }),
+      });
+    } else {
+      console.log('Verification token for', email, token);
+    }
+  } catch (e) {
+    console.error('Failed to send verification email', e);
+  }
   return NextResponse.json({ id: user.id, email: user.email });
 }


### PR DESCRIPTION
## Summary
- add notification dispatch to certificate expiry scheduler
- send verification and reset email tokens via webhooks

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: turbo: not found)


------
https://chatgpt.com/codex/tasks/task_e_68b80f05cca8832e80c502d3c17a217a